### PR TITLE
Fix: gitignore native storyloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 #
 storybook-static
 .cache
-.storybook-native/story-loader.js
+storybook.native/story-loader.js
 
 # OSX
 #


### PR DESCRIPTION
Update to #82 . Changed `story-loader.js` path in `.gitignore` to correct (actual) one.