### PR TITLE
Fix: Stepper component disable

### DIFF
--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -33,8 +33,8 @@ export default function Stepper({
   disableDecrement: originalDisableDecrement,
   disableIncrement: originalDisableIncrement,
 }: Props) {
-  const belowMin = min !== undefined && number <= min;
-  const aboveMax = max !== undefined && number >= max;
+  const belowMin = min != null && number <= min;
+  const aboveMax = max != null && number >= max;
   const disableDecrement = belowMin ?? originalDisableDecrement;
   const disableIncrement = aboveMax ?? originalDisableIncrement;
 

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -33,8 +33,8 @@ export default function Stepper({
   disableDecrement: originalDisableDecrement,
   disableIncrement: originalDisableIncrement,
 }: Props) {
-  const belowMin = min && number <= min;
-  const aboveMax = max && number >= max;
+  const belowMin = min !== undefined && number <= min;
+  const aboveMax = max !== undefined && number >= max;
   const disableDecrement = belowMin ?? originalDisableDecrement;
   const disableIncrement = aboveMax ?? originalDisableIncrement;
 

--- a/src/Stepper/Stepper.stories.js
+++ b/src/Stepper/Stepper.stories.js
@@ -124,7 +124,7 @@ storiesOf('Stepper', module)
     });
     const disableIncrement = boolean('Disable increment', false);
     const disableDecrement = boolean('Disable decrement', false);
-    const min = number('Min', -2);
+    const min = number('Min', 0);
     const max = number('Max', 2);
     const defaultNumber = number('Default number', 0);
     return (

--- a/src/Stepper/__tests__/index.test.js
+++ b/src/Stepper/__tests__/index.test.js
@@ -37,6 +37,52 @@ describe('Stepper', () => {
     expect(output).toMatchSnapshot();
   });
 
+  it('should have buttons disabled when min, max and number is zero', () => {
+    const { getAllByProps } = render(
+      <Stepper
+        onDecrement={onDecrement}
+        onIncrement={onIncrement}
+        min={0}
+        max={0}
+        number={0}
+      />
+    );
+    expect(
+      getAllByProps({
+        touchable: false,
+      })
+    ).toHaveLength(2);
+  });
+
+  it('should have buttons enabled when min, max is set to null', () => {
+    const { getAllByProps } = render(
+      // $FlowFixMe - flow disabled to test 'null' edge case
+      <Stepper
+        onDecrement={onDecrement}
+        onIncrement={onIncrement}
+        min={null}
+        max={null}
+        number={0}
+      />
+    );
+    expect(
+      getAllByProps({
+        touchable: true,
+      })
+    ).toHaveLength(2);
+  });
+
+  it('should have buttons enabled when min, max is not set', () => {
+    const { getAllByProps } = render(
+      <Stepper onDecrement={onDecrement} onIncrement={onIncrement} number={0} />
+    );
+    expect(
+      getAllByProps({
+        touchable: true,
+      })
+    ).toHaveLength(2);
+  });
+
   const { getByText, getByType, getAllByType, getAllByProps } = render(
     <Stepper
       onDecrement={onDecrement}


### PR DESCRIPTION
Fixed condition for `belowMin` and `aboveMax`. When `min` or `max` was set to zero it was always `false`.