### PR TITLE
Add: Icons available on Web (temporary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@callstack/eslint-config": "^3.0.0",
     "@emotion/core": "^0.13.1",
     "@emotion/styled": "^0.10.6",
+    "@kiwicom/orbit-components": "^0.22.1",
     "@storybook/addon-actions": "^4.0.7",
     "@storybook/addon-knobs": "^4.0.7",
     "@storybook/addon-links": "^4.0.6",
@@ -74,6 +75,7 @@
     "release-it": "^8.4.2",
     "rimraf": "^2.6.2",
     "snapshot-diff": "^0.4.0",
+    "styled-components": "^4.1.2",
     "webpack": "^4.25.1"
   },
   "config": {

--- a/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -49,16 +49,16 @@ exports[`Button - native should match snapshot diff 1`] = `
 +           }
 +         >
             <Text
-+             color=\\"#0176D2\\"
-+             size={20}
               style={
                 Array [
                   Object {
 +                   \\"fontFamily\\": \\"orbit-icons\\",
 +                 },
 +                 Object {
++                   \\"fontSize\\": 24,
++                 },
++                 Object {
 +                   \\"color\\": \\"#0176D2\\",
-+                   \\"fontSize\\": 20,
 +                 },
 +               ]
 +             }
@@ -151,16 +151,16 @@ exports[`Button - native should match snapshot diff 1`] = `
 +           }
 +         >
 +           <Text
-+             color=\\"#0176D2\\"
-+             size={20}
 +             style={
 +               Array [
 +                 Object {
 +                   \\"fontFamily\\": \\"orbit-icons\\",
 +                 },
 +                 Object {
++                   \\"fontSize\\": 24,
++                 },
++                 Object {
 +                   \\"color\\": \\"#0176D2\\",
-+                   \\"fontSize\\": 20,
 +                 },
 +               ]
 +             }
@@ -205,16 +205,12 @@ exports[`Button - native should match the snapshot 1`] = `
     disabled={false}
     leftIcon={
       <Icon
-        color="#46515e"
         name="calendar"
-        size={20}
       />
     }
     rightIcon={
       <Icon
-        color="#46515e"
         name="chevron-right"
-        size={20}
       />
     }
     sublabel="Button sublabel"
@@ -285,16 +281,16 @@ exports[`Button - web should match snapshot diff 1`] = `
 +         }
 +       >
           <Text
-+           color=\\"#0176D2\\"
-+           size={20}
             style={
               Array [
                 Object {
 +                 \\"fontFamily\\": \\"orbit-icons\\",
 +               },
 +               Object {
++                 \\"fontSize\\": 24,
++               },
++               Object {
 +                 \\"color\\": \\"#0176D2\\",
-+                 \\"fontSize\\": 20,
 +               },
 +             ]
 +           }
@@ -340,16 +336,16 @@ exports[`Button - web should match snapshot diff 1`] = `
 +         }
 +       >
 +         <Text
-+           color=\\"#0176D2\\"
-+           size={20}
 +           style={
 +             Array [
 +               Object {
 +                 \\"fontFamily\\": \\"orbit-icons\\",
 +               },
 +               Object {
++                 \\"fontSize\\": 24,
++               },
++               Object {
 +                 \\"color\\": \\"#0176D2\\",
-+                 \\"fontSize\\": 20,
 +               },
 +             ]
 +           }
@@ -382,16 +378,12 @@ exports[`Button - web should match the snapshot 1`] = `
     disabled={false}
     leftIcon={
       <Icon
-        color="#46515e"
         name="calendar"
-        size={20}
       />
     }
     rightIcon={
       <Icon
-        color="#46515e"
         name="chevron-right"
-        size={20}
       />
     }
     type="info"

--- a/src/Checkbox/CheckboxIcon.js
+++ b/src/Checkbox/CheckboxIcon.js
@@ -29,7 +29,7 @@ export default function CheckboxIcon({
         pressed && styles.boxPressed,
       ]}
     >
-      {checked && <Icon name="check" color={iconColor} size={14} />}
+      {checked && <Icon name="check" color={iconColor} size="small" />}
     </View>
   );
 }

--- a/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
@@ -34,16 +34,16 @@ exports[`CheckBox - native should match snapshot diff 1`] = `
 -   />
 +   >
 +     <Text
-+       color=\\"#00a991\\"
-+       size={14}
 +       style={
 +         Array [
 +           Object {
 +             \\"fontFamily\\": \\"orbit-icons\\",
 +           },
 +           Object {
++             \\"fontSize\\": 16,
++           },
++           Object {
 +             \\"color\\": \\"#00a991\\",
-+             \\"fontSize\\": 14,
 +           },
 +         ]
 +       }
@@ -146,16 +146,16 @@ exports[`CheckBox - web should match snapshot diff 1`] = `
 -     />
 +     >
 +       <Text
-+         color=\\"#00a991\\"
-+         size={14}
 +         style={
 +           Array [
 +             Object {
 +               \\"fontFamily\\": \\"orbit-icons\\",
 +             },
 +             Object {
++               \\"fontSize\\": 16,
++             },
++             Object {
 +               \\"color\\": \\"#00a991\\",
-+               \\"fontSize\\": 14,
 +             },
 +           ]
 +         }

--- a/src/FilterButton/FilterButton.js
+++ b/src/FilterButton/FilterButton.js
@@ -23,7 +23,7 @@ export default function FilterButton({
           color: isActive
             ? defaultTokens.paletteCloudNormal
             : defaultTokens.colorIconPrimary,
-          size: 18,
+          size: 'medium',
         });
 
   return (

--- a/src/Icon/Icon.native.js
+++ b/src/Icon/Icon.native.js
@@ -2,15 +2,11 @@
 
 import * as React from 'react';
 import { Text as RNText } from 'react-native';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import StyleSheet from '../PlatformStyleSheet';
 
 import iconsMap from './icons.json';
-
-export type Props = {|
-  +name: string,
-  size?: number,
-  color?: string,
-|};
+import type { Props } from './IconTypes';
 
 const getIconCharacter = name => {
   const icon = iconsMap[name];
@@ -24,22 +20,17 @@ const getIconCharacter = name => {
   return iconsMap[name].character;
 };
 
-export default function Icon({ name, color, size }: Props) {
+export default function Icon({
+  name,
+  color = '#46515e',
+  size = 'medium',
+}: Props) {
   return (
-    <RNText
-      color={color}
-      size={size}
-      style={[styles.icon, { color, fontSize: size }]}
-    >
+    <RNText style={[styles.icon, styles[size], { color }]}>
       {getIconCharacter(name)}
     </RNText>
   );
 }
-
-Icon.defaultProps = {
-  color: '#46515e',
-  size: 20,
-};
 
 const styles = StyleSheet.create({
   icon: {
@@ -49,4 +40,15 @@ const styles = StyleSheet.create({
       textAlignVertical: 'center',
     },
   },
+  /* eslint-disable react-native/no-unused-styles */
+  small: {
+    fontSize: parseFloat(defaultTokens.widthIconSmall),
+  },
+  medium: {
+    fontSize: parseFloat(defaultTokens.widthIconMedium),
+  },
+  large: {
+    fontSize: parseFloat(defaultTokens.widthIconLarge),
+  },
+  /* eslint-enable */
 });

--- a/src/Icon/Icon.stories.js
+++ b/src/Icon/Icon.stories.js
@@ -16,7 +16,7 @@ storiesOf('Icon', module)
   ))
   .add('Custom Icon', () => (
     <React.Fragment>
-      <Icon name="check" color="#46B655" size={80} />
+      <Icon name="check" color="#46B655" size="large" />
     </React.Fragment>
   ))
   .add('All Icons list', () => (

--- a/src/Icon/Icon.web.js
+++ b/src/Icon/Icon.web.js
@@ -1,0 +1,15 @@
+// @flow
+
+import * as React from 'react';
+import * as Icons from '@kiwicom/orbit-components/lib/icons'; // eslint-disable-line import/no-extraneous-dependencies
+
+import type { Props } from './IconTypes';
+
+export default function Icon({ name, color, size = 'medium' }: Props) {
+  const capitalizedName = name[0].toUpperCase() + name.slice(1);
+  const orbitName = capitalizedName.replace(/(-\w)/g, m => m[1].toUpperCase());
+  if (orbitName in Icons) {
+    return Icons[orbitName]({ customColor: color, size });
+  }
+  return <Icons.QuestionCircle customColor={color} size={size} />;
+}

--- a/src/Icon/IconTypes.js
+++ b/src/Icon/IconTypes.js
@@ -1,0 +1,9 @@
+// @flow
+
+type Size = 'small' | 'medium' | 'large';
+
+export type Props = {|
+  +name: string,
+  size?: Size,
+  color?: string,
+|};

--- a/src/Icon/IconsList.js
+++ b/src/Icon/IconsList.js
@@ -12,7 +12,7 @@ const keyExtractor = item => item;
 const renderItem = ({ item }) => (
   <View key={item} style={styles.item}>
     <Text>{item}</Text>
-    <Icon name={item} size={40} />
+    <Icon name={item} size="large" />
   </View>
 );
 

--- a/src/Icon/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Icon/__tests__/__snapshots__/index.test.js.snap
@@ -5,21 +5,15 @@ exports[`Icon should match snapshot diff between regular and custom icon 1`] = `
 - First value
 + Second value
 
-@@ -1,5 +1,5 @@
-  <Text
--   color=\\"#46515e\\"
--   size={20}
-+   color=\\"red\\"
-+   size={40}
-    style={
-      Array [
-@@ -8,6 +8,6 @@
+@@ -6,8 +6,8 @@
+        },
+        Object {
+-         \\"fontSize\\": 24,
++         \\"fontSize\\": 32,
         },
         Object {
 -         \\"color\\": \\"#46515e\\",
--         \\"fontSize\\": 20,
 +         \\"color\\": \\"red\\",
-+         \\"fontSize\\": 40,
         },
       ]"
 `;

--- a/src/Icon/__tests__/index.test.js
+++ b/src/Icon/__tests__/index.test.js
@@ -8,7 +8,7 @@ import { Icon } from '..';
 
 describe('Icon', () => {
   const { getByProps, getByText } = render(
-    <Icon name="check" size={40} color="red" />
+    <Icon name="check" size="large" color="red" />
   );
 
   it('should have correct icon character for icon name', () => {
@@ -16,14 +16,14 @@ describe('Icon', () => {
   });
 
   it('should have correct props', () => {
-    expect(getByProps({ size: 40 })).toBeDefined();
+    expect(getByProps({ size: 'large' })).toBeDefined();
     expect(getByProps({ name: 'check' })).toBeDefined();
     expect(getByProps({ color: 'red' })).toBeDefined();
   });
 
   it('should match snapshot diff between regular and custom icon', () => {
     const regular = render(<Icon name="check" />);
-    const custom = render(<Icon name="check" size={40} color="red" />);
+    const custom = render(<Icon name="check" size="large" color="red" />);
 
     expect(
       snapshotDiff(regular, custom, { contextLines: 2 })

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -31,7 +31,7 @@ export default function RadioButton({
         >
           {checked &&
             (isCheckType ? (
-              <Icon name="check" color="#ffffff" size={20} />
+              <Icon name="check" color="#ffffff" size="medium" />
             ) : (
               <View style={styles.bulletFill} />
             ))}

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -40,7 +40,7 @@ export default function Stepper({
 
   const iconProps = {
     color: defaultTokens.colorIconSecondary,
-    size: 14,
+    size: 'small',
   };
 
   let numberDisplayed = number;

--- a/src/Stepper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stepper/__tests__/__snapshots__/index.test.js.snap
@@ -51,7 +51,7 @@ exports[`Stepper should match the snapshot 1`] = `
       <Icon
         color="#7f91a8"
         name="minus"
-        size={14}
+        size="small"
       />
     }
     onPress={[MockFunction]}
@@ -72,7 +72,7 @@ exports[`Stepper should match the snapshot 1`] = `
       <Icon
         color="#7f91a8"
         name="plus"
-        size={14}
+        size="small"
       />
     }
     onPress={[MockFunction]}

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -38,7 +38,7 @@ const Prefix = ({ children, size, status }) => {
 
       return React.cloneElement(child, {
         color: iconColor,
-        size: size === 'small' ? 16 : 24,
+        size,
       });
     }
     return child;

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
   integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
 
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
+
 "@emotion/utils@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
@@ -948,6 +953,13 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz#b700d97385fa91affed60c71dfd51c67e9dad762"
   integrity sha512-QsYGKdhhuDFNq7bjm2r44y0mp5xW3uO3csuTPDWZc0OIiMQv+AIY5Cqwd4mJiC5N8estVl7qlvOx1hbtOuUWbw==
+
+"@kiwicom/orbit-components@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-components/-/orbit-components-0.22.1.tgz#d94cdf0afe2dea090c87497f4faad2b818df2678"
+  integrity sha512-+NniePsq/3EClr14F2wNMEJcGxNtTsfRvXYjEqycfDSkO1AQkSz1G+bF6CfMRIjqEl2NSDovjJa/RNV9HWjlyA==
+  dependencies:
+    "@kiwicom/orbit-design-tokens" "^0.2.5"
 
 "@kiwicom/orbit-design-tokens@^0.2.5":
   version "0.2.5"
@@ -2375,6 +2387,15 @@ babel-plugin-react-docgen@^2.0.0:
     lodash "^4.17.10"
     react-docgen "^3.0.0-rc.1"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.9.2.tgz#0e6a6587454dcb1c9a362a8fd31fc0b075ccd260"
+  integrity sha512-McnheW8RkBkur/mQw7rEwQO/oUUruQ/nIIj5LIRpsVL8pzG1oo1Y53xyvAYeOfamIrl4/ta7g1G/kuTR1ekO3A==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
+
 babel-plugin-syntax-async-functions@^6.13.0, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -2395,7 +2416,7 @@ babel-plugin-syntax-flow@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
   integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
 
-babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
@@ -4134,6 +4155,11 @@ crypto-random-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-in-js-utils@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
@@ -4178,6 +4204,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
+  integrity sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.2"
@@ -5406,7 +5441,7 @@ fbjs-scripts@^1.0.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7927,6 +7962,11 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.3.tgz#cdfdd942853f1a1b4c71c5336b8c49da0bf0273c"
+  integrity sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -9860,7 +9900,7 @@ react-inspector@^2.3.0:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.6.1:
+react-is@^16.6.0, react-is@^16.6.1:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
@@ -11359,6 +11399,32 @@ style-loader@^0.23.1:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
+
+styled-components@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.2.tgz#f8a685e3b2bcd03c5beac7f2c02bb6ad237da9b3"
+  integrity sha512-NdvWatJ2WLqZxAvto+oH0k7GAC/TlAUJTrHoXJddjbCrU6U23EmVbb9LXJBF+d6q6hH+g9nQYOWYPUeX/Vlc2w==
+  dependencies:
+    "@emotion/is-prop-valid" "^0.6.8"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 supports-color@5.5.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
This is a bit hacky, but we can now see icons in the storybook for web.
To use the icon of this component library inside a web project, we would need to install `@kiwicom/orbit-components` and `styled-components` as dependencies I believe. This would need to be tested and made precise. 