### PR TITLE
fix: Do not use react-native-status-bar-height on web

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -8,16 +8,6 @@ module.exports = {
         use:
           'react-native-web-image-loader?name=[name].[ext]&scalings[@2x]=2&scalings[-3x]=3',
       },
-      {
-        test: /\.js$/,
-        include: [
-          path.join(
-            __dirname,
-            '../node_modules/react-native-status-bar-height/index.js'
-          ),
-        ],
-        use: 'babel-loader',
-      },
     ],
   },
   resolve: {

--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Animated } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import { getStatusBarHeight } from 'react-native-status-bar-height';
+import { getStatusBarHeight } from '../utils/StatusBarHeight';
 
 import StyleSheet from '../PlatformStyleSheet';
 import InformativeNotification from './InformativeNotification';

--- a/src/utils/StatusBarHeight.js
+++ b/src/utils/StatusBarHeight.js
@@ -1,0 +1,3 @@
+// @flow
+
+export const getStatusBarHeight = () => 0;

--- a/src/utils/StatusBarHeight.native.js
+++ b/src/utils/StatusBarHeight.native.js
@@ -1,0 +1,3 @@
+// @flow
+
+export * from 'react-native-status-bar-height';


### PR DESCRIPTION
1. It won't be transpiled so we might have problems in projects like create-react-app
2. We do not need it