### PR TITLE
fix: Use data-test-id instead of testID on web

### DIFF
--- a/src/Button/Button.web.js
+++ b/src/Button/Button.web.js
@@ -46,8 +46,8 @@ export default function Button({
   if (href) {
     return (
       <a
-        testID={testID}
         href={href}
+        data-test-id={testID}
         style={{
           ...wrapperStyle,
           ...displayBlock(block, width),
@@ -63,7 +63,7 @@ export default function Button({
     <button
       type="button"
       onClick={onPress}
-      testID={testID}
+      data-test-id={testID}
       disabled={disabled}
       style={{
         ...wrapperStyle,


### PR DESCRIPTION
Closes #120.

This is ok. Just remember to use `data-test-id` on web. 

We could also write a babel plugin to enforce this or even easier... We can use https://www.npmjs.com/package/babel-plugin-jsx-remove-data-test-id and https://www.npmjs.com/package/babel-plugin-react-test-id to remove those attributes from production build.

If you would like any of the above, we can open an issue with it.