### PR TITLE
Added: DatePicker component

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -65,6 +65,8 @@ module.file_ext=.js
 module.file_ext=.jsx
 module.file_ext=.json
 module.file_ext=.native.js
+module.file_ext=.android.js
+module.file_ext=.ios.js
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@kiwicom/orbit-design-tokens": "^0.2.5",
     "react-native-shimmer": "^0.4.1",
+    "react-datepicker": "2.0.0",
     "react-native-status-bar-height": "^2.2.0",
     "styled-components": "^4.1.2"
   },

--- a/src/DatePicker/DatePicker.android.js
+++ b/src/DatePicker/DatePicker.android.js
@@ -1,0 +1,140 @@
+// @flow
+
+import * as React from 'react';
+import { DatePickerAndroid, TimePickerAndroid } from 'react-native';
+
+import type { Props } from './DatePickerTypes';
+
+export default class AndroidDatePicker extends React.Component<Props> {
+  componentDidUpdate = (prevProps: Props) => {
+    const { isVisible, mode } = this.props;
+
+    if (!prevProps.isVisible && isVisible) {
+      if (mode === 'date' || mode === 'datetime') {
+        this.showDatePicker();
+      } else {
+        this.showTimePicker();
+      }
+    }
+  };
+
+  componentDidMount = () => {
+    const { isVisible, mode } = this.props;
+
+    if (this.props && isVisible) {
+      if (mode === 'date' || mode === 'datetime') {
+        this.showDatePicker();
+      } else {
+        this.showTimePicker();
+      }
+    }
+  };
+
+  showDatePicker = async () => {
+    const {
+      minDate,
+      maxDate,
+      datePickerMode,
+      mode,
+      date = new Date(),
+      onConfirm,
+      onDismiss,
+    } = this.props;
+    let picker;
+    try {
+      picker = await DatePickerAndroid.open({
+        date,
+        minDate,
+        maxDate,
+        mode: datePickerMode,
+      });
+    } catch (e) {
+      console.warn('Cannot open date picker', e.message);
+      return;
+    }
+
+    const { action, year, month, day } = picker;
+    // $FlowFixMe - it has a reference to DatePickerAndroid.ios.js
+    if (action !== DatePickerAndroid.dismissedAction) {
+      let customDate;
+      if (date && !isNaN(date.getTime())) {
+        const hour = date.getHours();
+        const minute = date.getMinutes();
+        customDate = new Date(year, month, day, hour, minute);
+      } else {
+        customDate = new Date(year, month, day);
+      }
+
+      if (mode === 'datetime') {
+        const timeOptions = {
+          mode: datePickerMode,
+          hour: date && date.getHours(),
+          minute: date && date.getMinutes(),
+        };
+
+        let pickerTime;
+        try {
+          pickerTime = await TimePickerAndroid.open(timeOptions);
+        } catch (e) {
+          console.warn('Cannot open time picker', e.message);
+          return;
+        }
+
+        const { action: timeAction, hour, minute } = pickerTime;
+        // $FlowFixMe - it has a reference to DatePickerAndroid.ios.js
+        if (timeAction !== TimePickerAndroid.dismissedAction) {
+          const selectedDate = new Date(year, month, day, hour, minute);
+          onConfirm(selectedDate);
+        } else {
+          onDismiss();
+        }
+      } else {
+        onConfirm(customDate);
+      }
+    } else {
+      onDismiss();
+    }
+  };
+
+  showTimePicker = async () => {
+    const {
+      date = new Date(),
+      datePickerMode,
+      onConfirm,
+      onDismiss,
+    } = this.props;
+    let picker;
+    try {
+      picker = await TimePickerAndroid.open({
+        hour: date.getHours(),
+        minute: date.getMinutes(),
+        mode: datePickerMode,
+      });
+    } catch (e) {
+      console.warn('Cannot open time picker', e.message);
+      return;
+    }
+
+    const { action, hour, minute } = picker;
+    // $FlowFixMe - it has a reference to DatePickerAndroid.ios.js
+    if (action !== TimePickerAndroid.dismissedAction) {
+      let customDate;
+      if (date) {
+        // This prevents losing the Date elements, see issue #71
+        const year = date.getFullYear();
+        const month = date.getMonth();
+        const day = date.getDate();
+        customDate = new Date(year, month, day, hour, minute);
+      } else {
+        customDate = new Date().setHours(hour).setMinutes(minute);
+      }
+      onConfirm(customDate);
+    } else {
+      onDismiss();
+    }
+  };
+
+  render() {
+    return null;
+  }
+}

--- a/src/DatePicker/DatePicker.ios.js
+++ b/src/DatePicker/DatePicker.ios.js
@@ -1,0 +1,138 @@
+/* @flow */
+
+import * as React from 'react';
+import {
+  View,
+  DatePickerIOS,
+  Modal,
+  TouchableWithoutFeedback,
+} from 'react-native';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import { Text } from '../Text';
+import { Touchable } from '../Touchable';
+import { StyleSheet } from '../PlatformStyleSheet';
+
+import type { Props } from './DatePickerTypes';
+
+type State = {
+  date: Date,
+};
+
+export default class iOSDatePicker extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      date: props.date || new Date(),
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps: Props, nextState: State) {
+    const { date } = nextProps;
+
+    if (date && date !== nextState.date) {
+      return {
+        date,
+      };
+    }
+    return null;
+  }
+
+  setDefaultDate = () => {
+    this.setState({
+      date: new Date(),
+    });
+  };
+
+  handleDismiss = () => {
+    const { onDismiss } = this.props;
+
+    onDismiss();
+  };
+
+  handleConfirm = () => {
+    const { onConfirm } = this.props;
+    const { date } = this.state;
+
+    onConfirm(date);
+    this.setDefaultDate();
+  };
+
+  handleChangeDate = (date: Date) => {
+    this.setState({
+      date,
+    });
+  };
+
+  render() {
+    const { isVisible, mode, maxDate, minDate } = this.props;
+
+    const { date } = this.state;
+
+    return (
+      <Modal
+        transparent
+        visible={isVisible}
+        onRequestClose={this.handleDismiss}
+        animationType="slide"
+      >
+        <TouchableWithoutFeedback onPress={this.handleDismiss}>
+          <View style={styles.backdrop}>
+            <View style={styles.content}>
+              <DatePickerIOS
+                date={date}
+                onDateChange={this.handleChangeDate}
+                mode={mode}
+                maximumDate={maxDate}
+                minimumDate={minDate}
+              />
+              <View style={styles.buttonsContainer}>
+                <Touchable
+                  onPress={this.handleDismiss}
+                  style={styles.confirmButton}
+                >
+                  <Text style={styles.buttonText}>Cancel</Text>
+                </Touchable>
+                <Touchable
+                  style={styles.confirmButton}
+                  onPress={this.handleConfirm}
+                >
+                  <Text style={styles.buttonText}>OK</Text>
+                </Touchable>
+              </View>
+            </View>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    flexDirection: 'column',
+    backgroundColor: 'white',
+    borderRadius: parseFloat(defaultTokens.borderRadiusBadge),
+    width: '90%',
+  },
+  confirmButton: {
+    borderColor: defaultTokens.paletteWhite,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    height: 50,
+    justifyContent: 'center',
+  },
+  buttonText: {
+    textAlign: 'center',
+    color: defaultTokens.paletteProductNormal,
+    fontSize: parseFloat(defaultTokens.fontSizeButtonLarge),
+    fontWeight: 'normal',
+    backgroundColor: 'transparent',
+  },
+});

--- a/src/DatePicker/DatePicker.stories.js
+++ b/src/DatePicker/DatePicker.stories.js
@@ -1,0 +1,102 @@
+// @flow
+
+import * as React from 'react';
+import { View, Platform } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { withKnobs, select, date as dateAddon } from '@storybook/addon-knobs';
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
+
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import DatePicker from './DatePicker';
+import { StyleSheet } from '../PlatformStyleSheet';
+
+type State = {
+  isOpen: boolean,
+  date: string,
+};
+
+class DateTimePicker extends React.Component<{}, State> {
+  state = {
+    isOpen: false,
+    date: '',
+  };
+
+  showDatePicker = () => this.setState({ isOpen: true });
+
+  hideDatePicker = () => this.setState({ isOpen: false });
+
+  handleDateChange = date => {
+    this.setState({ date: date.toString() }, () => this.hideDatePicker());
+  };
+
+  render() {
+    const { isOpen, date } = this.state;
+    const mode = select('Mode', ['date', 'time', 'datetime'], 'date');
+    const minDateStringTimestamp = dateAddon(
+      'Min date',
+      new Date('Dec 20 2018')
+    );
+    const maxDateStringTimestamp = dateAddon(
+      'Max date',
+      new Date('Jan 20 2019')
+    );
+    let datePickerMode;
+
+    if (Platform.OS === 'android') {
+      datePickerMode = select(
+        'Picker Mode',
+        ['calendar', 'spinner', 'default'],
+        'default'
+      );
+    }
+
+    return (
+      <View>
+        {Platform.OS !== 'web' && (
+          <Button onPress={this.showDatePicker}>Open date picker</Button>
+        )}
+        <DatePicker
+          isVisible={isOpen}
+          onDismiss={this.hideDatePicker}
+          onConfirm={this.handleDateChange}
+          minDate={new Date(minDateStringTimestamp)}
+          maxDate={new Date(maxDateStringTimestamp)}
+          mode={mode}
+          datePickerMode={datePickerMode}
+          customInput={
+            <View style={styles.customInputContainer}>
+              <View style={styles.icon}>
+                <Icon name="calendar" color={defaultTokens.colorTextWhite} />
+              </View>
+              <Text type="white" size="large">
+                Date: {date}
+              </Text>
+            </View>
+          }
+        />
+
+        {Platform.OS !== 'web' && <Text>Selected date: {date}</Text>}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  customInputContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+    padding: parseFloat(defaultTokens.spaceSmall),
+    backgroundColor: defaultTokens.paletteProductNormal,
+    borderRadius: parseFloat(defaultTokens.borderRadiusLarge),
+  },
+  icon: {
+    marginEnd: 10,
+  },
+});
+
+storiesOf('DatePicker', module)
+  .addDecorator(withKnobs)
+  .add('Playground', () => <DateTimePicker />);

--- a/src/DatePicker/DatePicker.web.js
+++ b/src/DatePicker/DatePicker.web.js
@@ -1,0 +1,52 @@
+// @flow
+
+import * as React from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+
+import type { Props } from './DatePickerTypes';
+
+type State = {
+  date: Date,
+};
+
+export default class WebDatePicker extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      date: props.date || new Date(),
+    };
+  }
+
+  handleConfirm = (date: Date) => {
+    const { onConfirm } = this.props;
+
+    this.setState({
+      date,
+    });
+
+    onConfirm(date);
+  };
+
+  render() {
+    const { minDate, maxDate, customInput, mode } = this.props;
+    const { date } = this.state;
+
+    const showTimeSelect = mode === 'time' || mode === 'datetime';
+    const showTimeSelectOnly = mode === 'time';
+
+    return (
+      <DatePicker
+        selected={date}
+        onChange={this.handleConfirm}
+        minDate={minDate}
+        maxDate={maxDate}
+        customInput={customInput}
+        showTimeSelect={showTimeSelect}
+        showTimeSelectOnly={showTimeSelectOnly}
+        timeIntervals={1}
+      />
+    );
+  }
+}

--- a/src/DatePicker/DatePickerTypes.js
+++ b/src/DatePicker/DatePickerTypes.js
@@ -1,0 +1,15 @@
+// @flow
+
+import * as React from 'react';
+
+export type Props = {|
+  +isVisible: boolean, // this prop is supported only on mobile
+  +mode?: 'date' | 'time' | 'datetime',
+  +datePickerMode?: 'calendar' | 'spinner' | 'default', // this prop is supported only on android
+  +date?: Date,
+  +minDate?: Date,
+  +maxDate?: Date,
+  +onConfirm: Date => void,
+  +onDismiss: () => void,
+  +customInput?: React.Node, // this prop is supported only on web
+|};

--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export { default as DatePicker } from './DatePicker';

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export {
   TimelinePriorityBoarding,
 } from './TimelineInformation';
 export { Tooltip, TooltipBubble } from './Tooltip';
+export { DatePicker } from './DatePicker';
 
 /* Utils */
 export { StyleSheet } from './PlatformStyleSheet';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4148,6 +4148,14 @@ create-react-class@^15.6.2, create-react-class@^15.6.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@<=0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4326,6 +4334,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+date-fns@^2.0.0-alpha.23:
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.26.tgz#e46afd73a2b50e0359446309ee7cb631d7467227"
+  integrity sha512-UAptCZ53MVimUFR8MXTyHED51AVGIqFlBfWgiS/KIoSYiJGrWScx4PYQVNSWfK2Js+43OlokCW1ttnexBTJ5Bg==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -5492,7 +5505,7 @@ fbjs-scripts@^1.0.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -6106,6 +6119,11 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@5.0.0:
   version "5.0.0"
@@ -9428,6 +9446,11 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+popper.js@^1.14.4:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.6.tgz#ab20dd4edf9288b8b3b6531c47c361107b60b4b0"
+  integrity sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -9922,6 +9945,17 @@ react-color@^2.14.1:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
+react-datepicker@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.0.0.tgz#5818edfdd08af1b18cbc02b8a1c842cec906606f"
+  integrity sha512-3L3PrZLqbnEIBDXh4RkwlClCaCOFOPd2WYezo4vjXz5PSogrpXtG6UuAc21JtF8+3bBgcsZ/2BUH5F5b89VHsA==
+  dependencies:
+    classnames "^2.2.5"
+    date-fns "^2.0.0-alpha.23"
+    prop-types "^15.6.0"
+    react-onclickoutside "^6.7.1"
+    react-popper "^1.0.2"
+
 react-deep-force-update@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"
@@ -10203,6 +10237,23 @@ react-native@^0.57.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
     yargs "^9.0.0"
+
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+  integrity sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
+
+react-popper@^1.0.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.2.tgz#e723a0a7fe1c42099a13e5d494e9d7d74b352af4"
+  integrity sha512-UbFWj55Yt9uqvy0oZ+vULDL2Bw1oxeZF9/JzGyxQ5ypgauRH/XlarA5+HLZWro/Zss6Ht2kqpegtb6sYL8GUGw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "<=0.2.2"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -11928,6 +11979,11 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -12276,6 +12332,13 @@ warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Summary: For mobile we are using date pickers from `react-native` based on the native date pickers. For web we are going to use `react-datepicker` library and adjust it a bit to our requirements using prop `customInput`.

Fixes: #89 