### PR TITLE
Fix: Icon size is not consistent

### DIFF
--- a/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -35,7 +35,7 @@ exports[`Button - native should match snapshot diff 1`] = `
         }
       >
         <View
-@@ -43,14 +43,40 @@
+@@ -43,14 +43,43 @@
               \\"alignItems\\": \\"center\\",
               \\"flexDirection\\": \\"row\\",
             }
@@ -56,6 +56,9 @@ exports[`Button - native should match snapshot diff 1`] = `
 +                 },
 +                 Object {
 +                   \\"fontSize\\": 24,
++                   \\"height\\": 24,
++                   \\"lineHeight\\": 24,
++                   \\"width\\": 24,
 +                 },
 +                 Object {
 +                   \\"color\\": \\"#0176D2\\",
@@ -76,7 +79,7 @@ exports[`Button - native should match snapshot diff 1`] = `
                 },
                 undefined,
                 undefined,
-@@ -72,11 +98,11 @@
+@@ -72,11 +101,11 @@
                     \\"fontSize\\": 16,
                     \\"fontWeight\\": \\"bold\\",
                     \\"lineHeight\\": 21,
@@ -89,7 +92,7 @@ exports[`Button - native should match snapshot diff 1`] = `
                 ],
               ]
             }
-@@ -89,9 +115,83 @@
+@@ -89,9 +118,86 @@
             Object {
               \\"alignItems\\": \\"center\\",
               \\"flexDirection\\": \\"row\\",
@@ -159,6 +162,9 @@ exports[`Button - native should match snapshot diff 1`] = `
 +                 },
 +                 Object {
 +                   \\"fontSize\\": 24,
++                   \\"height\\": 24,
++                   \\"lineHeight\\": 24,
++                   \\"width\\": 24,
 +                 },
 +                 Object {
 +                   \\"color\\": \\"#0176D2\\",
@@ -269,7 +275,7 @@ exports[`Button - web should match snapshot diff 1`] = `
       }
     >
       <View
-@@ -42,14 +40,40 @@
+@@ -42,14 +40,43 @@
             \\"alignItems\\": \\"center\\",
             \\"flexDirection\\": \\"row\\",
           }
@@ -290,6 +296,9 @@ exports[`Button - web should match snapshot diff 1`] = `
 +               },
 +               Object {
 +                 \\"fontSize\\": 24,
++                 \\"height\\": 24,
++                 \\"lineHeight\\": 24,
++                 \\"width\\": 24,
 +               },
 +               Object {
 +                 \\"color\\": \\"#0176D2\\",
@@ -310,7 +319,7 @@ exports[`Button - web should match snapshot diff 1`] = `
               },
               undefined,
               undefined,
-@@ -71,11 +95,11 @@
+@@ -71,11 +98,11 @@
                   \\"fontSize\\": 16,
                   \\"fontWeight\\": \\"bold\\",
                   \\"lineHeight\\": 21,
@@ -323,7 +332,7 @@ exports[`Button - web should match snapshot diff 1`] = `
               ],
             ]
           }
-@@ -88,8 +112,35 @@
+@@ -88,8 +115,38 @@
           Object {
             \\"alignItems\\": \\"center\\",
             \\"flexDirection\\": \\"row\\",
@@ -346,6 +355,9 @@ exports[`Button - web should match snapshot diff 1`] = `
 +               },
 +               Object {
 +                 \\"fontSize\\": 24,
++                 \\"height\\": 24,
++                 \\"lineHeight\\": 24,
++                 \\"width\\": 24,
 +               },
 +               Object {
 +                 \\"color\\": \\"#0176D2\\",

--- a/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`CheckBox - native should match snapshot diff 1`] = `
   >
     <View
       style={
-@@ -28,17 +28,36 @@
+@@ -28,17 +28,39 @@
             \\"borderWidth\\": 1,
             \\"height\\": 20,
             \\"justifyContent\\": \\"center\\",
@@ -41,6 +41,9 @@ exports[`CheckBox - native should match snapshot diff 1`] = `
 +           },
 +           Object {
 +             \\"fontSize\\": 16,
++             \\"height\\": 16,
++             \\"lineHeight\\": 16,
++             \\"width\\": 16,
 +           },
 +           Object {
 +             \\"color\\": \\"#00a991\\",
@@ -57,7 +60,7 @@ exports[`CheckBox - native should match snapshot diff 1`] = `
         Object {
           \\"display\\": \\"flex\\",
           \\"flex\\": 1,
-@@ -55,21 +74,27 @@
+@@ -55,21 +77,27 @@
               \\"fontFamily\\": \\"Roboto\\",
               \\"fontSize\\": 14,
               \\"fontWeight\\": \\"400\\",
@@ -131,7 +134,7 @@ exports[`CheckBox - web should match snapshot diff 1`] = `
     >
       <View
         style={
-@@ -46,17 +51,36 @@
+@@ -46,17 +51,39 @@
               \\"borderWidth\\": 1,
               \\"height\\": 20,
               \\"justifyContent\\": \\"center\\",
@@ -154,6 +157,9 @@ exports[`CheckBox - web should match snapshot diff 1`] = `
 +             },
 +             Object {
 +               \\"fontSize\\": 16,
++               \\"height\\": 16,
++               \\"lineHeight\\": 16,
++               \\"width\\": 16,
 +             },
 +             Object {
 +               \\"color\\": \\"#00a991\\",
@@ -170,7 +176,7 @@ exports[`CheckBox - web should match snapshot diff 1`] = `
           Object {
             \\"display\\": \\"flex\\",
             \\"flex\\": 1,
-@@ -73,22 +97,28 @@
+@@ -73,22 +100,28 @@
                 \\"fontFamily\\": \\"Roboto\\",
                 \\"fontSize\\": 14,
                 \\"fontWeight\\": \\"400\\",

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -35,6 +35,13 @@ export default function Icon({
   );
 }
 
+const getSizeStyle = (size: number): Object => ({
+  fontSize: size,
+  width: size,
+  height: size,
+  lineHeight: size,
+});
+
 const styles = StyleSheet.create({
   icon: {
     fontFamily: 'orbit-icons',
@@ -44,14 +51,8 @@ const styles = StyleSheet.create({
     },
   },
   /* eslint-disable react-native/no-unused-styles */
-  small: {
-    fontSize: parseFloat(defaultTokens.widthIconSmall),
-  },
-  medium: {
-    fontSize: parseFloat(defaultTokens.widthIconMedium),
-  },
-  large: {
-    fontSize: parseFloat(defaultTokens.widthIconLarge),
-  },
+  small: getSizeStyle(parseFloat(defaultTokens.widthIconSmall)),
+  medium: getSizeStyle(parseFloat(defaultTokens.widthIconMedium)),
+  large: getSizeStyle(parseFloat(defaultTokens.widthIconLarge)),
   /* eslint-enable */
 });

--- a/src/Icon/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Icon/__tests__/__snapshots__/index.test.js.snap
@@ -5,11 +5,17 @@ exports[`Icon should match snapshot diff between regular and custom icon 1`] = `
 - First value
 + Second value
 
-@@ -6,8 +6,8 @@
+@@ -6,11 +6,11 @@
         },
         Object {
 -         \\"fontSize\\": 24,
+-         \\"height\\": 24,
+-         \\"lineHeight\\": 24,
+-         \\"width\\": 24,
 +         \\"fontSize\\": 32,
++         \\"height\\": 32,
++         \\"lineHeight\\": 32,
++         \\"width\\": 32,
         },
         Object {
 -         \\"color\\": \\"#46515e\\",

--- a/src/Stepper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stepper/__tests__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`Stepper should match snapshot diff between small and normal input 1`] =
 - <Stepper number={0} onDecrement={[Function mockConstructor]} onIncrement={[Function mockConstructor]} />
 + <Stepper number={0} onDecrement={[Function mockConstructor]} onIncrement={[Function mockConstructor]} showNumber={false} />
 
-@@ -62,29 +62,2 @@
+@@ -65,29 +65,2 @@
     </View>
 -   <Text
 -     style={

--- a/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
+++ b/src/TimelineInformation/__tests__/__snapshots__/TimelineInformation.test.js.snap
@@ -21,10 +21,10 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
   >
     <Text
       style={
-@@ -24,11 +27,11 @@
-          },
-          Object {
-            \\"fontSize\\": 16,
+@@ -27,11 +30,11 @@
+            \\"height\\": 16,
+            \\"lineHeight\\": 16,
+            \\"width\\": 16,
           },
           Object {
 -           \\"color\\": \\"#171b1e\\",
@@ -34,7 +34,7 @@ exports[`TimelineInformation should match snapshot diff 1`] = `
         ]
       }
     >
-@@ -56,11 +59,11 @@
+@@ -59,11 +62,11 @@
             },
             Object {
               \\"fontSize\\": 14,


### PR DESCRIPTION
• Enhanced icon styles to make sizes and vertical centering consistent on all platforms.
• Update of impacted snapshots

Related to #136 (icon centering problem)

Before - android | ios | web
![before](https://user-images.githubusercontent.com/2660330/50589880-b6662780-0e88-11e9-9442-212ac978aa55.jpg)

After
![after](https://user-images.githubusercontent.com/2660330/50589878-b1a17380-0e88-11e9-9a41-1b6d041c01d0.jpg)