### PR TITLE
Updated: Correct file structure for StyleSheet helper

### DIFF
--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { BadgeProps, BadgeType } from './BadgeTypes';
 import { textColor, wrapperColor } from './styles';
 

--- a/src/Button/ButtonInner.js
+++ b/src/Button/ButtonInner.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 
 import { Icon } from '../Icon';
-import StyleSheet from '../PlatformStyleSheet/index';
+import { StyleSheet } from '../PlatformStyleSheet';
 import ButtonTitle from './ButtonTitle';
 import type { ButtonType } from './ButtonTypes';
 import { textColor, wrapperColor } from './styles';

--- a/src/Button/ButtonTitle.js
+++ b/src/Button/ButtonTitle.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import { Text } from '../Text';
 import { textColor } from './styles';

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import Touchable from '../Button/Touchable';
 
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';

--- a/src/CarrierLogo/CarrierLogo.js
+++ b/src/CarrierLogo/CarrierLogo.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View, Image, PixelRatio } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { Props } from './CarrierLogoTypes';
 import { SIZE_OPTIONS } from './consts';
 import { logoSizes } from './styles';

--- a/src/Checkbox/CheckboxIcon.js
+++ b/src/Checkbox/CheckboxIcon.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { Icon } from '../Icon';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import theme, { parsePxValue } from './styles';
 import type { CheckboxIconProps } from './CheckboxTypes';
 

--- a/src/Checkbox/CheckboxShared.js
+++ b/src/Checkbox/CheckboxShared.js
@@ -6,7 +6,7 @@ import CheckboxText from './CheckboxText';
 import CheckboxIcon from './CheckboxIcon';
 import Hoverable from './Hoverable';
 import theme, { parseStringToFloat } from './styles';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { CheckboxSharedProps, CheckboxSharedState } from './CheckboxTypes';
 
 class CheckboxShared extends React.Component<

--- a/src/Checkbox/CheckboxText.js
+++ b/src/Checkbox/CheckboxText.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Text, View, Platform } from 'react-native';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import theme, { parsePxValue } from './styles';
 
 type Props = {|

--- a/src/ConnectionCard/BadgesContainer.js
+++ b/src/ConnectionCard/BadgesContainer.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { ScrollView } from 'react-native';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type Props = {|
   +children: React.Node,

--- a/src/ConnectionCard/ConnectionCard.js
+++ b/src/ConnectionCard/ConnectionCard.js
@@ -10,7 +10,7 @@ import BadgesContainer from './BadgesContainer';
 import type { BadgeProps } from '../Badge/BadgeTypes';
 import type { LocalizedPriceProps } from '../LocalizedPrice/LocalizedPriceTypes';
 import type { TripSectorProps } from './ConnectionCardTypes';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type TripSectorWithId = { ...TripSectorProps, id: number };
 type BadgeWithId = { ...BadgeProps, id: number };

--- a/src/ConnectionCard/ConnectionCardRow.js
+++ b/src/ConnectionCard/ConnectionCardRow.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 
 type Props = {|

--- a/src/ConnectionCard/TripSector.js
+++ b/src/ConnectionCard/TripSector.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View, Image } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 import { CarrierLogo } from '../CarrierLogo';
 import type { TripSectorProps } from './ConnectionCardTypes';

--- a/src/FilterButton/FilterButton.js
+++ b/src/FilterButton/FilterButton.js
@@ -6,7 +6,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Text } from '../Text';
 import Touchable from '../Button/Touchable';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import type { Props } from './FilterButtonTypes';
 

--- a/src/FormFeedback/FormFeedback.js
+++ b/src/FormFeedback/FormFeedback.js
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import type { Props } from './FormFeedbackTypes';
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Text as RNText } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import iconsMap from './icons.json';
 import type { Props } from './IconTypes';

--- a/src/Icon/IconsList.js
+++ b/src/Icon/IconsList.js
@@ -5,7 +5,7 @@ import { FlatList, View } from 'react-native';
 
 import { Icon } from '.';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import iconsMap from './icons.json';
 
 const keyExtractor = item => item;

--- a/src/Loader/PageLoader.js
+++ b/src/Loader/PageLoader.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Platform, View } from 'react-native';
 
 import Loader from './Loader';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 export default function PageLoader() {
   return (

--- a/src/LocalizedPrice/LocalizedPrice.js
+++ b/src/LocalizedPrice/LocalizedPrice.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { LocalizedPriceProps } from './LocalizedPriceTypes';
 
 export default function LocalizedPrice({

--- a/src/Notification/ImportantNotification.js
+++ b/src/Notification/ImportantNotification.js
@@ -6,7 +6,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Icon } from '../Icon';
 import Touchable from '../Button/Touchable';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 import type { NotificationStyleType } from '../types';

--- a/src/Notification/InformativeNotification.js
+++ b/src/Notification/InformativeNotification.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Animated } from 'react-native';
 
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import { Text } from '../Text';
 
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';

--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -5,7 +5,7 @@ import { Animated } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { getStatusBarHeight } from '../utils/StatusBarHeight';
 
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import InformativeNotification from './InformativeNotification';
 import ImportantNotification from './ImportantNotification';
 

--- a/src/Notification/NotificationExample.js
+++ b/src/Notification/NotificationExample.js
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 
 import Notification from './Notification';
 import { Button } from '../Button';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import type { NotificationType } from '../types';
 

--- a/src/PlaceCard/Image/CityImage.js
+++ b/src/PlaceCard/Image/CityImage.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import StyleSheet from '../../PlatformStyleSheet';
+import { StyleSheet } from '../../PlatformStyleSheet';
 import NetworkImage from './NetworkImage';
 
 import type { StylePropType } from '../../PlatformStyleSheet/StyleTypes';

--- a/src/PlaceCard/Image/NetworkImage.js
+++ b/src/PlaceCard/Image/NetworkImage.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Image } from 'react-native';
 
-import StyleSheet from '../../PlatformStyleSheet';
+import { StyleSheet } from '../../PlatformStyleSheet';
 
 import type { StylePropType } from '../../PlatformStyleSheet/StyleTypes';
 

--- a/src/PlaceCard/PlaceCard.js
+++ b/src/PlaceCard/PlaceCard.js
@@ -10,7 +10,7 @@ import AdaptableBadge from '../shared/AdaptableBadge';
 import BlackToAlpha from './assets/black-to-alpha-vertical.png';
 
 import CityImage from './Image/CityImage';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type Props = {|
   +imageUrl?: string,

--- a/src/PlaceCard/Placeholder.js
+++ b/src/PlaceCard/Placeholder.js
@@ -6,7 +6,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import Shimmer from '../Placeholder/shimmer';
 import connect from '../Placeholder/connect';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 const Placeholder = () => (
   <View style={styles.container}>

--- a/src/Placeholder/shimmer/index.native.js
+++ b/src/Placeholder/shimmer/index.native.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Image } from 'react-native';
 import Shimmer from 'react-native-shimmer';
-import StyleSheet from '../../PlatformStyleSheet';
+import { StyleSheet } from '../../PlatformStyleSheet';
 
 const ShimmeringLoader = ({ style, ...rest }: any) => (
   <Shimmer {...rest}>

--- a/src/PlatformStyleSheet/StyleSheet.js
+++ b/src/PlatformStyleSheet/StyleSheet.js
@@ -1,0 +1,57 @@
+// @flow
+
+import { StyleSheet, Platform } from 'react-native'; // eslint-disable-line no-restricted-imports
+
+import type { StyleObjectType, PlatformStyleObjectType } from './StyleTypes';
+
+/**
+ * This StyleSheet allows to define platform differences easily:
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flexDirection: 'row',
+ *     ios: {
+ *       padding: 10,
+ *     },
+ *     android: {
+ *       padding: 20,
+ *     },
+ *     web: {
+ *       padding: 30,
+ *     },
+ *   }
+ * })
+ */
+export default {
+  absoluteFill: StyleSheet.absoluteFill,
+
+  absoluteFillObject: {
+    position: 'absolute',
+    start: 0,
+    end: 0,
+    top: 0,
+    bottom: 0,
+  },
+
+  hairlineWidth: StyleSheet.hairlineWidth,
+
+  flatten: StyleSheet.flatten,
+
+  create(styles: PlatformStyleObjectType): StyleObjectType {
+    const platformStyles = {};
+    Object.keys(styles).forEach(name => {
+      let { ios, android, web, ...style } = { ...styles[name] }; // eslint-disable-line prefer-const
+      if (ios && Platform.OS === 'ios') {
+        style = { ...style, ...ios };
+      }
+      if (android && Platform.OS === 'android') {
+        style = { ...style, ...android };
+      }
+      if (web && Platform.OS === 'web') {
+        style = { ...style, ...web };
+      }
+      platformStyles[name] = style;
+    });
+    return StyleSheet.create(platformStyles);
+  },
+};

--- a/src/PlatformStyleSheet/__flowtests__/Styles.flowtest.js
+++ b/src/PlatformStyleSheet/__flowtests__/Styles.flowtest.js
@@ -1,6 +1,6 @@
 // @flow
 
-import StyleSheet from '..';
+import { StyleSheet } from '..';
 import { type StyleObjectType, type StylePropType } from '../StyleTypes';
 
 /**

--- a/src/PlatformStyleSheet/index.js
+++ b/src/PlatformStyleSheet/index.js
@@ -1,57 +1,9 @@
 // @flow
 
-import { StyleSheet, Platform } from 'react-native'; // eslint-disable-line no-restricted-imports
+export { default as StyleSheet } from './StyleSheet';
 
-import type { StyleObjectType, PlatformStyleObjectType } from './StyleTypes';
-
-/**
- * This StyleSheet allows to define platform differences easily:
- *
- * const styles = StyleSheet.create({
- *   container: {
- *     flexDirection: 'row',
- *     ios: {
- *       padding: 10,
- *     },
- *     android: {
- *       padding: 20,
- *     },
- *     web: {
- *       padding: 30,
- *     },
- *   }
- * })
- */
-export default {
-  absoluteFill: StyleSheet.absoluteFill,
-
-  absoluteFillObject: {
-    position: 'absolute',
-    start: 0,
-    end: 0,
-    top: 0,
-    bottom: 0,
-  },
-
-  hairlineWidth: StyleSheet.hairlineWidth,
-
-  flatten: StyleSheet.flatten,
-
-  create(styles: PlatformStyleObjectType): StyleObjectType {
-    const platformStyles = {};
-    Object.keys(styles).forEach(name => {
-      let { ios, android, web, ...style } = { ...styles[name] }; // eslint-disable-line prefer-const
-      if (ios && Platform.OS === 'ios') {
-        style = { ...style, ...ios };
-      }
-      if (android && Platform.OS === 'android') {
-        style = { ...style, ...android };
-      }
-      if (web && Platform.OS === 'web') {
-        style = { ...style, ...web };
-      }
-      platformStyles[name] = style;
-    });
-    return StyleSheet.create(platformStyles);
-  },
-};
+export type {
+  StylePropType,
+  StyleObjectType,
+  PlatformStyleObjectType,
+} from './StyleTypes';

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View, TouchableWithoutFeedback } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import type { Props } from './RadioButtonTypes';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import { Icon } from '../Icon';
 
 export default function RadioButton({

--- a/src/RadioButton/RadioButton.stories.js
+++ b/src/RadioButton/RadioButton.stories.js
@@ -6,7 +6,7 @@ import { select, boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { RadioButton } from '.';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 const pressAction = action('radio-button-press');
 const bulletTypes = ['bullet', 'check'];

--- a/src/Rating/Rating.js
+++ b/src/Rating/Rating.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 
 type Props = {|

--- a/src/Rating/Rating.stories.js
+++ b/src/Rating/Rating.stories.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import { number, withKnobs } from '@storybook/addon-knobs';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import { Rating } from '.';
 
 storiesOf('Rating', module)

--- a/src/SearchParamsSummary/SearchParamsSummary.js
+++ b/src/SearchParamsSummary/SearchParamsSummary.js
@@ -7,7 +7,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import AdaptableBadge from '../shared/AdaptableBadge';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type Trip = {|
   +city: string,

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -7,7 +7,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import StepperButton from './StepperButton';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 
 type Props = {|

--- a/src/Stepper/StepperButton.js
+++ b/src/Stepper/StepperButton.js
@@ -6,7 +6,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Icon } from '../Icon';
 import Touchable from '../Button/Touchable';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 
 type ButtonProps = {|

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Text as RNText, Platform } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import { createStylesGenerator } from '../utils';
 import {
   align as alignTypes,

--- a/src/TextInput/FormLabel.js
+++ b/src/TextInput/FormLabel.js
@@ -5,7 +5,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { View } from 'react-native';
 
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type Props = {|
   +children: React.Node,

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -14,7 +14,7 @@ import { Text } from '../Text';
 import FormLabel from './FormLabel';
 import { Icon } from '../Icon';
 import { FormFeedback } from '../FormFeedback';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import { createStylesGenerator } from '../utils';
 import { fontSize, height } from './styles';
 

--- a/src/TimelineInformation/TimelineCabinBaggage.js
+++ b/src/TimelineInformation/TimelineCabinBaggage.js
@@ -6,7 +6,7 @@ import TimelineInformation from './TimelineInformation';
 
 import { Icon } from '../Icon';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type Props = {|
   +cabinBaggageWarning: string,

--- a/src/TimelineInformation/TimelineInformation.js
+++ b/src/TimelineInformation/TimelineInformation.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 
 import { Icon } from '../Icon';

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -5,7 +5,7 @@ import { Dimensions, View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import type { ViewLayoutEvent } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import TooltipBubble from './TooltipBubble';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 type Props = {|
   +isActive?: boolean,

--- a/src/Tooltip/TooltipBubble.js
+++ b/src/Tooltip/TooltipBubble.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 
 type Props = {|

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ export {
 export { Tooltip, TooltipBubble } from './Tooltip';
 
 /* Utils */
-export { default as StyleSheet } from './PlatformStyleSheet';
+export { StyleSheet } from './PlatformStyleSheet';
 
 /* Types */
 export type {
   StylePropType,
   StyleObjectType,
   PlatformStyleObjectType,
-} from './PlatformStyleSheet/StyleTypes.js';
+} from './PlatformStyleSheet';

--- a/src/shared/AdaptableBadge.js
+++ b/src/shared/AdaptableBadge.js
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 
 import { Text } from '../Text';
-import StyleSheet from '../PlatformStyleSheet';
+import { StyleSheet } from '../PlatformStyleSheet';
 
 import type { StylePropType } from '../PlatformStyleSheet/StyleTypes';
 


### PR DESCRIPTION
This is to follow the convention that exports should be in index.js file at the root of the folder, and to improve searchability of file related to StyleSheet