### PR TITLE
docs: Added convention to write flow types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,3 +109,19 @@ node scripts/generateTypes.js
 ```
 
 to update `src/types/_generated-types/index.js`. This ensures flow types are accurate.
+
+## Style Guide
+
+### Writing flow types in different files
+
+When writing `flow` types, leave them as close to the component as possible, ideally in the same file. They should be written just after the imports and before the component declaration.
+
+However, since this is a multi-platform component library, if some types need to be reused in different files specific to each platform, the accepted practice is to extract said types into a file `ComponentTypes.js` in the same `Component` folder. They would typically consist of `Props` and `State` types.
+
+> For instance, have a look at [Checkbox](./src/Checkbox). Since we have a `Checkbox.native.js` file and a `Checkbox.web.js` file, we need to extract the common types into `CheckboxTypes.js`. However, `CheckboxShared.js` is a cross-platform component and it contains its types inside the same file.
+
+If you need to import types in other components, the convention is to do the following:
+
+```javascript
+import type { Props as ComponentProps } from '../Component/Component';
+```

--- a/src/Checkbox/Checkbox.native.js
+++ b/src/Checkbox/Checkbox.native.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import CheckboxShared from './CheckboxShared';
-import type { CheckboxProps } from './CheckboxTypes';
+import type { Props } from './CheckboxTypes';
 
 export default function Checkbox({
   label,
@@ -11,7 +11,7 @@ export default function Checkbox({
   checked,
   info,
   onChange,
-}: CheckboxProps) {
+}: Props) {
   return (
     <CheckboxShared
       label={label}

--- a/src/Checkbox/Checkbox.web.js
+++ b/src/Checkbox/Checkbox.web.js
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import CheckboxShared from './CheckboxShared';
-import type { CheckboxProps } from './CheckboxTypes';
+import type { Props } from './CheckboxTypes';
 
 const styleInput = {
   display: 'none',
@@ -20,7 +20,7 @@ export default function Checkbox({
   name,
   info,
   onChange,
-}: CheckboxProps) {
+}: Props) {
   const labelStyle = {
     display: 'flex',
     flexDirection: 'row',

--- a/src/Checkbox/CheckboxIcon.js
+++ b/src/Checkbox/CheckboxIcon.js
@@ -5,7 +5,15 @@ import { View } from 'react-native';
 import { Icon } from '../Icon';
 import { StyleSheet } from '../PlatformStyleSheet';
 import theme, { parsePxValue } from './styles';
-import type { CheckboxIconProps } from './CheckboxTypes';
+
+type Props = {|
+  +checked?: boolean,
+  +hasError?: boolean,
+  +disabled?: boolean,
+  +focused?: boolean,
+  +hovered?: boolean,
+  +pressed?: boolean,
+|};
 
 export default function CheckboxIcon({
   checked,
@@ -14,7 +22,7 @@ export default function CheckboxIcon({
   focused,
   hovered,
   pressed,
-}: CheckboxIconProps) {
+}: Props) {
   const errorState = hasError && !disabled && !checked;
   const iconColor = disabled
     ? theme.orbit.colorIconCheckboxRadioDisabled

--- a/src/Checkbox/CheckboxShared.js
+++ b/src/Checkbox/CheckboxShared.js
@@ -7,13 +7,24 @@ import CheckboxIcon from './CheckboxIcon';
 import Hoverable from './Hoverable';
 import theme, { parseStringToFloat } from './styles';
 import { StyleSheet } from '../PlatformStyleSheet';
-import type { CheckboxSharedProps, CheckboxSharedState } from './CheckboxTypes';
 
-class CheckboxShared extends React.Component<
-  CheckboxSharedProps,
-  CheckboxSharedState
-> {
-  constructor(props: CheckboxSharedProps) {
+type Props = {|
+  +label?: React.Node,
+  +hasError?: boolean,
+  +disabled?: boolean,
+  +checked?: boolean,
+  +info?: React.Node,
+  +onPress?: () => void,
+|};
+
+type State = {|
+  focusDisplayed: boolean,
+  hovered: boolean,
+  pressed: boolean,
+|};
+
+class CheckboxShared extends React.Component<Props, State> {
+  constructor(props: Props) {
     super(props);
 
     this.state = {

--- a/src/Checkbox/CheckboxTypes.js
+++ b/src/Checkbox/CheckboxTypes.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-export type CheckboxProps = {|
+export type Props = {|
   +label?: React.Node,
   +value?: string, // this prop is currently used only on web
   +hasError?: boolean,
@@ -11,34 +11,4 @@ export type CheckboxProps = {|
   +name?: string, // this prop is currently used only on web
   +info?: React.Node,
   +onChange?: () => void,
-|};
-
-export type CheckboxSharedProps = {|
-  +label?: React.Node,
-  +hasError?: boolean,
-  +disabled?: boolean,
-  +checked?: boolean,
-  +info?: React.Node,
-  +onPress?: () => void,
-|};
-
-export type CheckboxSharedState = {|
-  focusDisplayed: boolean,
-  hovered: boolean,
-  pressed: boolean,
-|};
-
-export type CheckboxIconProps = {|
-  +checked?: boolean,
-  +hasError?: boolean,
-  +disabled?: boolean,
-  +focused?: boolean,
-  +hovered?: boolean,
-  +pressed?: boolean,
-|};
-
-export type HoverableProps = {|
-  +children: React.Element<any>,
-  +onMouseEnter?: () => void,
-  +onMouseLeave?: () => void,
 |};

--- a/src/Checkbox/Hoverable.js
+++ b/src/Checkbox/Hoverable.js
@@ -1,13 +1,18 @@
 // @flow
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import { Platform } from 'react-native';
-import type { HoverableProps } from './CheckboxTypes';
 import HoverMonitor from './HoverMonitor';
+
+type Props = {|
+  +children: React.Element<any>,
+  +onMouseEnter?: () => void,
+  +onMouseLeave?: () => void,
+|};
 
 const hoverMonitor = HoverMonitor();
 
-class Hoverable extends Component<HoverableProps> {
+class Hoverable extends React.Component<Props> {
   handleOnMouseEnter = () => {
     const { onMouseEnter } = this.props;
     if (onMouseEnter && hoverMonitor.hoverEnabled) {


### PR DESCRIPTION
Summary: CONTRIBUTING now contains guidelines on how to write flow types for components which have platform specific files; refactored the types for Checkbox component as an example of what is expected.