### PR TITLE
Docs: Added our commit template and instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,13 +92,21 @@ and it is then easier to test the interactions with the action logger, and play 
 
 - We prefix our commit messages with one of the following to signify the kind of change:
 
-  - `fix`: bug fixes, e.g. fix some colors, paddings.
-  - `feat`: new features, e.g. add new component.
-  - `refactor`: code/structure refactor, e.g. new structure folder for components/ extracting component to separate file.
-  - `docs`: changes into documentation,
-  - `test`: adding or updating tests, e.g. unit, snapshot testing.
-  - `chore`: tooling changes, e.g. change circle ci config.
+  - `Fix`: bug fixes, e.g. fix some colors, paddings.
+  - `Feat`: new features, e.g. add new component.
+  - `Refactor`: code/structure refactor, e.g. new structure folder for components/ extracting component to separate file.
+  - `Docs`: changes into documentation,
+  - `Test`: adding or updating tests, e.g. unit, snapshot testing.
+  - `Chore`: tooling changes, e.g. change circle ci config.
   - `BREAKING`: for changes that break existing usage, e.g. change API of a component.
+
+**To make this easier**, please run the following command:
+
+```bash
+git config --local commit.template docs/commit-template.txt
+```
+
+This will pre-fill your commit message with a [template](docs/commit-template.txt) whenever you run `git commit`, reminding you to follow the convention and to add a summary.
 
 ## Updating Icons
 

--- a/docs/commit-template.txt
+++ b/docs/commit-template.txt
@@ -1,0 +1,15 @@
+
+# <Fix/Feat/...>: <one-line summary>
+# e.g. Feat: Added Icon component
+
+Summary: 
+# Summary: <longer description, documenting the history of the repository>
+# e.g. Summary: For Icon component to work on web, it was necessary to add dependency on @kiwicom/orbit-components. Since mobile version relies on a font file, it should be possible to use the font on the web as well. Created issue to improve this in the future.
+
+# `Fix`: bug fixes, e.g. fix some colors, paddings.
+# `Feat`: new features, e.g. add new component.
+# `Refactor`: code/structure refactor, e.g. new structure folder for components/ extracting component to separate file.
+# `Docs`: changes into documentation,
+# `Test`: adding or updating tests, e.g. unit, snapshot testing.
+# `Chore`: tooling changes, e.g. change circle ci config.
+# `BREAKING`: for changes that break existing usage, e.g. change API of a component.


### PR DESCRIPTION
Summary: This commit template is introduced to try and improve our commit message quality; the resulting git history will be more useful and documenting. Instructions on how to set it up were added to the contributing guidelines. (I also think that commit messages should start with a capital letter, so I modified the docs to reflect that.)