### PR TITLE
Fix: Removed react-native-shimmer dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,7 +137,6 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-shimmer')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/android/app/src/main/java/com/storybooknative/MainApplication.java
+++ b/android/app/src/main/java/com/storybooknative/MainApplication.java
@@ -3,7 +3,6 @@ package com.storybooknative;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
-import com.oblador.shimmer.RNShimmerPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -23,8 +22,7 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNShimmerPackage()
+          new MainReactPackage()
       );
     }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,3 @@
 rootProject.name = 'storybooknative'
-include ':react-native-shimmer'
-project(':react-native-shimmer').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-shimmer/android')
 
 include ':app'

--- a/ios/storybooknative.xcodeproj/project.pbxproj
+++ b/ios/storybooknative.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		5C04BEA7D09C4DC4B05BB661 /* Roboto-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3368E9B6BC24CE8AFE7E255 /* Roboto-MediumItalic.ttf */; };
 		90151CF9607749A28BB60FDD /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0808ED4D12B4404482E493B9 /* Roboto-Regular.ttf */; };
 		F9A904A78F284EE6989903AF /* orbit-icons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4EF6E07BA1764ABC8E910490 /* orbit-icons.ttf */; };
-		B23851ECBB1E4C43B308D9BF /* libRNShimmer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FDCCF2CA5E104BAB8EB18502 /* libRNShimmer.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -357,8 +356,6 @@
 		D3368E9B6BC24CE8AFE7E255 /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; name = "Roboto-MediumItalic.ttf"; path = "../fonts/Roboto/Roboto-MediumItalic.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		0808ED4D12B4404482E493B9 /* Roboto-Regular.ttf */ = {isa = PBXFileReference; name = "Roboto-Regular.ttf"; path = "../fonts/Roboto/Roboto-Regular.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		4EF6E07BA1764ABC8E910490 /* orbit-icons.ttf */ = {isa = PBXFileReference; name = "orbit-icons.ttf"; path = "../fonts/orbit-icons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		D1E0166DE4954D52A5F6372A /* RNShimmer.xcodeproj */ = {isa = PBXFileReference; name = "RNShimmer.xcodeproj"; path = "../node_modules/react-native-shimmer/ios/RNShimmer.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		FDCCF2CA5E104BAB8EB18502 /* libRNShimmer.a */ = {isa = PBXFileReference; name = "libRNShimmer.a"; path = "libRNShimmer.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -386,7 +383,6 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
-				B23851ECBB1E4C43B308D9BF /* libRNShimmer.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -573,7 +569,6 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
-				D1E0166DE4954D52A5F6372A /* RNShimmer.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1222,13 +1217,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/storybooknative.app/storybooknative";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Debug;
 		};
@@ -1247,13 +1235,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/storybooknative.app/storybooknative";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Release;
 		};
@@ -1273,10 +1254,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = storybooknative;
 				VERSIONING_SYSTEM = "apple-generic";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Debug;
 		};
@@ -1295,10 +1272,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = storybooknative;
 				VERSIONING_SYSTEM = "apple-generic";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Release;
 		};
@@ -1325,13 +1298,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Debug;
 		};
@@ -1358,13 +1324,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Release;
 		};
@@ -1390,13 +1349,6 @@
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/storybooknative-tvOS.app/storybooknative-tvOS";
 				TVOS_DEPLOYMENT_TARGET = 10.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Debug;
 		};
@@ -1422,13 +1374,6 @@
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/storybooknative-tvOS.app/storybooknative-tvOS";
 				TVOS_DEPLOYMENT_TARGET = 10.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../node_modules/react-native-shimmer/ios/**",
-				);
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Summary: Removed `react-native-shimmer` native dependencies. Library was removed with `PlaceCard` component ( moved to `Margarita`).
Which caused build errors on both platforms when fresh `node_modules` were installed.