### PR TITLE
FIX: Notification example button

### DIFF
--- a/src/Notification/NotificationExample.js
+++ b/src/Notification/NotificationExample.js
@@ -37,7 +37,7 @@ export default class NotificationExample extends React.Component<Props> {
     const { notificationType, onDismiss } = this.props;
     return (
       <View style={styles.container}>
-        <Button onPress={this.renderNotification}>Press</Button>
+        <Button onPress={this.renderNotification} label="Press" />
         <Notification
           ref={this.refToNotification}
           notificationType={notificationType}


### PR DESCRIPTION
Summary: In notification example, button didnt have a label but string wihtout text component wrapper