### PR TITLE
Fix: Unified DatePicker behavior

### DIFF
--- a/src/DatePicker/DatePicker.android.js
+++ b/src/DatePicker/DatePicker.android.js
@@ -6,6 +6,11 @@ import { DatePickerAndroid, TimePickerAndroid } from 'react-native';
 import type { Props } from './DatePickerTypes';
 
 export default class AndroidDatePicker extends React.Component<Props> {
+  static defaultProps = {
+    mode: 'date',
+    datePickerMode: 'default',
+  };
+
   componentDidUpdate = (prevProps: Props) => {
     const { isVisible, mode } = this.props;
 

--- a/src/DatePicker/DatePicker.ios.js
+++ b/src/DatePicker/DatePicker.ios.js
@@ -27,6 +27,10 @@ const parsePropsToState = ({ date }: Props) => {
 };
 
 export default class iOSDatePicker extends React.Component<Props, State> {
+  static defaultProps = {
+    mode: 'date',
+  };
+
   constructor(props: Props) {
     super(props);
 

--- a/src/DatePicker/DatePicker.web.js
+++ b/src/DatePicker/DatePicker.web.js
@@ -7,7 +7,11 @@ import { StyleSheet } from '../PlatformStyleSheet';
 import DatePickerDayTile from './DatePickerDayTile';
 import { Button } from '../Button';
 import { Text } from '../Text';
-import { getPreviousMonthData, getNextMonthData } from './DatePickerHelpers';
+import {
+  getPreviousMonthData,
+  getNextMonthData,
+  getStartOfDayTime,
+} from './DatePickerHelpers';
 
 import type { Props } from './DatePickerTypes';
 
@@ -66,11 +70,11 @@ export default class WebDatePicker extends React.Component<Props, State> {
 
     const monthLength = new Date(year, month + 1, 0).getDate();
     const startDay = new Date(year, month, 1).getDay();
-    const selectedDay = new Date(
-      date.getFullYear(),
-      date.getMonth(),
-      date.getDate()
-    );
+    const selectedDateTime = getStartOfDayTime(date);
+    const minDateTime = minDate ? getStartOfDayTime(minDate) : 0;
+    const maxDateTime = maxDate
+      ? getStartOfDayTime(maxDate)
+      : Number.MAX_SAFE_INTEGER;
     const backDisabled =
       minDate && year <= minDate.getFullYear() && month <= minDate.getMonth();
     const forwardDisabled =
@@ -81,14 +85,12 @@ export default class WebDatePicker extends React.Component<Props, State> {
       const dayId = i + 1 - startDay;
       const tempDateTime =
         dayId > 0 ? new Date(year, month, dayId).getTime() : 0;
-      const disabled =
-        tempDateTime < (minDate ?? 0) ||
-        tempDateTime > (maxDate ?? Number.MAX_SAFE_INTEGER);
+      const disabled = tempDateTime < minDateTime || tempDateTime > maxDateTime;
       dayTiles.push(
         <DatePickerDayTile
           key={`${year}-${month}-${i}`}
           dayId={dayId}
-          selected={tempDateTime === selectedDay.getTime()}
+          selected={tempDateTime === selectedDateTime}
           disabled={disabled}
           onDaySelect={this.handleDaySelect}
         />

--- a/src/DatePicker/DatePickerDayTile.js
+++ b/src/DatePicker/DatePickerDayTile.js
@@ -27,7 +27,7 @@ export default class DatePickerDayTile extends React.Component<Props, State> {
     };
   }
 
-  handleDayClick = () => {
+  handleDayPress = () => {
     const { onDaySelect, dayId } = this.props;
     onDaySelect(dayId);
   };
@@ -56,7 +56,7 @@ export default class DatePickerDayTile extends React.Component<Props, State> {
       >
         <TouchableWithoutFeedback
           disabled={selected || disabled}
-          onPress={this.handleDayClick}
+          onPress={this.handleDayPress}
         >
           <View
             style={[

--- a/src/DatePicker/DatePickerHelpers.js
+++ b/src/DatePicker/DatePickerHelpers.js
@@ -28,3 +28,6 @@ export const getNextMonthData = (state: State): MonthSwapResult => {
     year,
   };
 };
+
+export const getStartOfDayTime = (date: Date): number =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();

--- a/src/DatePicker/__tests__/index.test.js
+++ b/src/DatePicker/__tests__/index.test.js
@@ -1,6 +1,10 @@
 // @flow
 
-import { getPreviousMonthData, getNextMonthData } from '../DatePickerHelpers';
+import {
+  getPreviousMonthData,
+  getNextMonthData,
+  getStartOfDayTime,
+} from '../DatePickerHelpers';
 
 describe('DatePicker', () => {
   test('getPreviousMonthData > should decrease month number', () => {
@@ -49,5 +53,11 @@ describe('DatePicker', () => {
       month: 0,
       year: 2020,
     });
+  });
+
+  test('getStartOfDayTime > should reset date time to start of the day', () => {
+    const testDay = new Date(2019, 0, 1, 10, 32, 5, 12);
+    const resultTime = new Date(2019, 0, 1).getTime();
+    expect(getStartOfDayTime(testDay)).toBe(resultTime);
   });
 });


### PR DESCRIPTION
Summary:
- Set default `mode` to `date` for iOS and Android.
- Fixed bug in `web` version, when `minDate` tile was disabled in cases where time of the day was set to different value than 0.