### PR TITLE
Update Badge style

### DIFF
--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -34,18 +34,17 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     flexDirection: 'row',
     flexWrap: 'wrap',
-    borderRadius: parseFloat(defaultTokens.borderRadiusBadge),
-    paddingHorizontal: 8,
-    height: parseFloat(defaultTokens.heightBadge),
+    borderRadius: parseFloat(defaultTokens.borderRadiusNormal),
+    paddingHorizontal: 4,
     web: {
       width: 'fit-content',
     },
   },
   text: {
     fontSize: 12,
-    lineHeight: 22,
+    lineHeight: 18, // @TODO parseFloat(defaultTokens.heightBadge) - after design tokens update
     fontWeight: '500',
-    letterSpacing: 0.59,
+    letterSpacing: 0.3,
     color: defaultTokens.colorTextBadgeDark,
   },
 });

--- a/src/Badge/styles/index.js
+++ b/src/Badge/styles/index.js
@@ -9,8 +9,8 @@ export const wrapperColor = {
   info: defaultTokens.backgroundBadgeInfo,
   neutral: defaultTokens.backgroundBadgeNeutral,
   success: defaultTokens.backgroundBadgeSuccess,
-  warning: defaultTokens.backgroundBadgeWarning,
-  white: defaultTokens.backgroundBadgeWhite,
+  warning: '#F9971E', // @TODO defaultTokens.backgroundBadgeWarning - after design tokens update
+  white: '#F5F7F9', // @TODO defaultTokens.backgroundBadgeWhite - after design tokens update
 };
 
 export const textColor = {
@@ -20,6 +20,6 @@ export const textColor = {
   info: defaultTokens.colorTextBadgeInfo,
   neutral: defaultTokens.colorTextBadgeNeutral,
   success: defaultTokens.colorTextBadgeSuccess,
-  warning: defaultTokens.colorTextBadgeWarning,
-  white: defaultTokens.colorTextBadgeWhite,
+  warning: '#FFFFFF', // @TODO defaultTokens.colorTextBadgeWarning - after design tokens update
+  white: '#7F91A8', // @TODO defaultTokens.colorTextBadgeWhite - after design tokens update
 };


### PR DESCRIPTION
Graphic design for badges is different than our in `universal-components'. So that is the reason for this PR. 

In the future, we need to have orbit design tokens updated because there are different badge background/text colours and height. I sent those issues to orbit team.


<img width="290" alt="screenshot 2019-01-14 at 17 23 46" src="https://user-images.githubusercontent.com/858321/51125684-748e9700-1821-11e9-8fe0-7ad0b4dd5154.png">
