### PR TITLE
Fix: Button background color in web version

### DIFF
--- a/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -215,7 +215,7 @@ exports[`Button - web should match snapshot diff 1`] = `
 - First value
 + Second value
 
-@@ -1,20 +1,18 @@
+@@ -1,21 +1,19 @@
 - <button
 -   disabled={false}
 -   onClick={[Function mockConstructor]}
@@ -223,6 +223,7 @@ exports[`Button - web should match snapshot diff 1`] = `
 +   href=\\"https://lolilol.com\\"
     style={
       Object {
+        \\"backgroundColor\\": \\"transparent\\",
         \\"border\\": 0,
         \\"cursor\\": \\"pointer\\",
         \\"display\\": \\"inline-block\\",
@@ -239,7 +240,7 @@ exports[`Button - web should match snapshot diff 1`] = `
       style={
         Array [
           Object {
-@@ -26,14 +24,14 @@
+@@ -27,14 +25,14 @@
             \\"paddingHorizontal\\": 8,
             \\"paddingVertical\\": 11,
           },
@@ -256,7 +257,7 @@ exports[`Button - web should match snapshot diff 1`] = `
       }
     >
       <View
-@@ -42,17 +40,76 @@
+@@ -43,17 +41,76 @@
             \\"alignItems\\": \\"center\\",
             \\"flexDirection\\": \\"row\\",
           }
@@ -342,6 +343,7 @@ exports[`Button - web should match the snapshot 1`] = `
   href="https://lolilol.com"
   style={
     Object {
+      "backgroundColor": "transparent",
       "border": 0,
       "cursor": "pointer",
       "display": "inline-block",

--- a/src/Button/styles/index.web.js
+++ b/src/Button/styles/index.web.js
@@ -23,6 +23,7 @@ export const wrapperStyle = {
   border: 0,
   padding: 0,
   textDecoration: 'none',
+  backgroundColor: 'transparent',
 };
 
 export function disabledStyle(disabled: boolean) {


### PR DESCRIPTION
Summary: 
Removed white corners in web version (mobile versions are ok). 
It was caused by default button background color.
Solved by overriding `backgroundColor` value to `transparent`.

Before:
<img width="267" alt="screenshot 2019-01-15 at 17 52 44" src="https://user-images.githubusercontent.com/2660330/51196907-63608b80-18f0-11e9-8f2b-bfaed8b94dd2.png">

Default button style before override (with `buttonface` color for background):
<img width="229" alt="screenshot 2019-01-15 at 17 52 29" src="https://user-images.githubusercontent.com/2660330/51196912-678ca900-18f0-11e9-8503-335fdd93760a.png">
