### PR TITLE
Docs: Added link to the docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Component library compatible with Expo/React Native projects as well as React ap
 
 Relies on [react-native-web](https://github.com/necolas/react-native-web) to port components, written with a React Native first approach, to the web.
 
-Storybook (web version): <https://kiwicom-universal-components.netlify.com>
+[📘 Storybook](https://kiwicom-universal-components.netlify.com) |
+[📚 Documentation](https://kiwicom-universal-components-docs.netlify.com)
 
 ## Usage
 


### PR DESCRIPTION
Summary: Documentation will now be built whenever we push to `master`
It is available at https://kiwicom-universal-components-docs.netlify.com