### PR TITLE
Fix: Exported IconNameType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ export { Slider } from './Slider';
 export { StyleSheet } from './PlatformStyleSheet';
 
 /* Types */
+export type { IconNameType } from './types/_generated-types';
+
 export type {
   StylePropType,
   StyleObjectType,


### PR DESCRIPTION
Summary: This type is needed whenever you want to create components based off our Icon component.