### PR TITLE
Fix: Unified Button and TextInput border radius

### DIFF
--- a/src/Button/ButtonInner.js
+++ b/src/Button/ButtonInner.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 
+import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { Icon } from '../Icon';
 import { StyleSheet } from '../PlatformStyleSheet';
 import ButtonTitle from './ButtonTitle';
@@ -108,10 +109,10 @@ const styleSheet = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    paddingHorizontal: 8,
+    paddingHorizontal: parseInt(defaultTokens.spaceXSmall, 10),
     paddingVertical: 11,
-    height: 44,
-    borderRadius: 6,
+    height: parseInt(defaultTokens.heightButtonNormal, 10),
+    borderRadius: parseInt(defaultTokens.borderRadiusLarge, 10),
   },
   disabled: {
     opacity: 0.5,

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -270,7 +270,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     width: '100%',
-    borderRadius: parseFloat(defaultTokens.borderRadiusNormal),
+    borderRadius: parseFloat(defaultTokens.borderRadiusLarge),
     paddingHorizontal: parseFloat(defaultTokens.spaceSmall),
     backgroundColor: defaultTokens.backgroundInputDisabled,
     web: {


### PR DESCRIPTION
Summary:
Updated `TextInput` `borderRadius` to new value according to actual designs and to be unified with `Button`.
Value for `Button` is now set from `orbit-design-tokens` but stays the same.

To prevent small inconsistencies like below while used together.
<img width="76" alt="screenshot 2019-01-17 at 18 23 21" src="https://user-images.githubusercontent.com/2660330/51336576-2bd71800-1a85-11e9-8425-8408c6f6a4b6.png">
