### PR TITLE
Fix: Text component cascades styles

### DIFF
--- a/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -35,7 +35,7 @@ exports[`Button - native should match snapshot diff 1`] = `
         }
       >
         <View
-@@ -43,18 +43,124 @@
+@@ -43,18 +43,110 @@
               \\"alignItems\\": \\"center\\",
               \\"flexDirection\\": \\"row\\",
             }
@@ -95,20 +95,6 @@ exports[`Button - native should match snapshot diff 1`] = `
 +                 Object {
 +                   \\"fontFamily\\": \\"Roboto\\",
 +                   \\"margin\\": 0,
-+                 },
-+                 undefined,
-+                 undefined,
-+                 Object {
-+                   \\"fontSize\\": 14,
-+                 },
-+                 Object {
-+                   \\"fontSize\\": 14,
-+                 },
-+                 Object {
-+                   \\"color\\": \\"#46515e\\",
-+                 },
-+                 Object {
-+                   \\"textAlign\\": \\"left\\",
 +                 },
 +                 Array [
 +                   Object {},

--- a/src/FilterButton/__tests__/__snapshots__/index.test.js.snap
+++ b/src/FilterButton/__tests__/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`FilterButton should match snapshot diff between active and inactive inp
 -         },
 +         false,
         ]
-@@ -71,5 +69,3 @@
+@@ -57,5 +55,3 @@
                 },
 -               Object {
 -                 \\"color\\": \\"#e8edf1\\",

--- a/src/Rating/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Rating/__tests__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`Rating should match snapshot diff 1`] = `
 - <Rating />
 + <Rating rating={3} style={{\\"color\\": \\"#ffb100\\"}} />
 
-@@ -21,12 +21,14 @@
+@@ -7,12 +7,14 @@
         },
         Array [
           Object {

--- a/src/Stepper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stepper/__tests__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`Stepper should match snapshot diff between small and normal input 1`] =
 - <Stepper number={0} onDecrement={[Function mockConstructor]} onIncrement={[Function mockConstructor]} />
 + <Stepper number={0} onDecrement={[Function mockConstructor]} onIncrement={[Function mockConstructor]} showNumber={false} />
 
-@@ -65,29 +65,2 @@
+@@ -65,14 +65,2 @@
     </View>
 -   <Text
 -     style={
@@ -14,21 +14,6 @@ exports[`Stepper should match snapshot diff between small and normal input 1`] =
 -           \\"fontFamily\\": \\"Roboto\\",
 -           \\"margin\\": 0,
 -         },
--         undefined,
--         undefined,
--         Object {
--           \\"fontSize\\": 14,
--         },
--         Object {
--           \\"fontSize\\": 14,
--         },
--         Object {
--           \\"color\\": \\"#46515e\\",
--         },
--         Object {
--           \\"textAlign\\": \\"left\\",
--         },
--         undefined,
 -       ]
 -     }
 -   >

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -21,34 +21,35 @@ const fontSizeGen = createStylesGenerator('fontSize', fontSize);
 const alignGen = createStylesGenerator('textAlign', alignTypes);
 
 const Text = ({
-  align = 'left',
+  align,
   children,
   dataTest,
   italic,
   numberOfLines,
-  size = 'normal',
+  size,
   style,
-  type = 'primary',
+  type,
   uppercase,
-  weight = 'normal',
-}: TextType) => (
-  <RNText
-    data-test={dataTest}
-    style={[
-      styles.text,
-      italic && styles.italic,
-      uppercase && styles.uppercase,
-      styles[weight],
-      styles[size],
-      styles[type],
-      styles[align],
-      style && style,
-    ]}
-    numberOfLines={numberOfLines}
-  >
-    {children}
-  </RNText>
-);
+  weight,
+}: TextType) => {
+  const textStyle = [styles.text];
+  italic && textStyle.push(styles.italic);
+  uppercase && textStyle.push(styles.uppercase);
+  weight && textStyle.push(styles[weight]);
+  size && textStyle.push(styles[size]);
+  type && textStyle.push(styles[type]);
+  align && textStyle.push(styles[align]);
+  style && textStyle.push(style);
+  return (
+    <RNText
+      data-test={dataTest}
+      style={textStyle}
+      numberOfLines={numberOfLines}
+    >
+      {children}
+    </RNText>
+  );
+};
 const styles = StyleSheet.create({
   text: {
     margin: 0,

--- a/src/Text/Text.stories.js
+++ b/src/Text/Text.stories.js
@@ -21,7 +21,13 @@ const customText =
 storiesOf('Text', module)
   .addDecorator(withKnobs)
   .addDecorator(getStory => <View style={style}>{getStory()}</View>)
-  .add('Primary text', () => <Text>{customText}</Text>)
+  .add('Cascading styles', () => (
+    <Text style={{ color: 'blue', fontSize: 22 }}>
+      Test
+      <Text style={{ color: 'red' }}>Nested test</Text>
+    </Text>
+  ))
+  .add('Primary text', () => <Text type="primary">{customText}</Text>)
   .add('Secondary text', () => <Text type="secondary">{customText}</Text>)
   .add('Attention text', () => <Text type="attention">{customText}</Text>)
   .add('Status text', () => (

--- a/src/Text/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Text/__tests__/__snapshots__/index.test.js.snap
@@ -5,39 +5,33 @@ exports[`Text should match snapshot diff 1`] = `
 - First value
 + Second value
 
-@@ -3,24 +3,28 @@
+@@ -3,10 +3,28 @@
       Array [
         Object {
           \\"fontFamily\\": \\"Roboto\\",
           \\"margin\\": 0,
         },
--       undefined,
--       undefined,
-        Object {
--         \\"fontSize\\": 14,
++       Object {
 +         \\"fontStyle\\": \\"italic\\",
-        },
-        Object {
--         \\"fontSize\\": 14,
++       },
++       Object {
 +         \\"textTransform\\": \\"uppercase\\",
-        },
-        Object {
--         \\"color\\": \\"#46515e\\",
++       },
++       Object {
 +         \\"fontWeight\\": \\"700\\",
-        },
-        Object {
--         \\"textAlign\\": \\"left\\",
++       },
++       Object {
 +         \\"fontSize\\": 16,
-        },
++       },
 +       Object {
 +         \\"color\\": \\"#7f91a8\\",
 +       },
 +       Object {
 +         \\"textAlign\\": \\"center\\",
 +       },
-        undefined,
       ]
     }
   >
-    Lorem ipsum"
+    Lorem ipsum
+  </Text>"
 `;

--- a/src/TextInput/__tests__/__snapshots__/index.test.js.snap
+++ b/src/TextInput/__tests__/__snapshots__/index.test.js.snap
@@ -5,12 +5,12 @@ exports[`TextInput should match snapshot diff between small and normal input 1`]
 - <TextInput label=\\"Label\\" />
 + <TextInput label=\\"Label\\" size=\\"small\\" />
 
-@@ -61,3 +61,3 @@
+@@ -47,3 +47,3 @@
           Object {
 -           \\"height\\": 44,
 +           \\"height\\": 32,
           },
-@@ -93,3 +93,3 @@
+@@ -79,3 +79,3 @@
             Object {
 -             \\"height\\": 44,
 +             \\"height\\": 32,


### PR DESCRIPTION
Summary: To extend React Native's Text component, we should allow styles to cascade. This behaviour was prevented because default values ewere set for the size, the weight and the type.

Closes #198