### PR TITLE
Fix: CarrierLogo carriers length

### DIFF
--- a/src/CarrierLogo/CarrierLogo.js
+++ b/src/CarrierLogo/CarrierLogo.js
@@ -14,7 +14,8 @@ export default function CarrierLogo({
   size = SIZE_OPTIONS.LARGE,
   carriers = [],
 }: Props) {
-  const carriersLength = carriers.length;
+  const parsedCarriers = parseCarriers(carriers);
+  const carriersLength = parsedCarriers.length;
   return (
     <View
       style={[
@@ -22,7 +23,7 @@ export default function CarrierLogo({
         carriersLength > 1 ? sizeStyles[SIZE_OPTIONS.LARGE] : sizeStyles[size],
       ]}
     >
-      {parseCarriers(carriers).map((carrierData, index) => (
+      {parsedCarriers.map((carrierData, index) => (
         <Image
           key={carrierData.code}
           style={[

--- a/src/CarrierLogo/__tests__/index.test.js
+++ b/src/CarrierLogo/__tests__/index.test.js
@@ -15,10 +15,18 @@ describe('CarrierLogo', () => {
     { code: 'VY', name: 'Vueling' },
     { code: 'OK', name: 'Czech Airlines' },
   ];
-  const { getAllByType } = render(<CarrierLogo carriers={carriers} />);
 
   it('should contain correct number of images', () => {
+    const { getAllByType } = render(<CarrierLogo carriers={carriers} />);
     expect(getAllByType(Image)).toHaveLength(4);
+  });
+
+  it('should contain correct number of images with correct size when duplicate carriers data are supplied', () => {
+    const { getAllByType, getByType } = render(
+      <CarrierLogo carriers={[carriers[0], carriers[0]]} />
+    );
+    expect(getAllByType(Image)).toHaveLength(1);
+    expect(getByType(Image).props.source.uri).toMatch(/64/);
   });
 
   it('should match snapshot diff', () => {


### PR DESCRIPTION
Summary: Fixed wrong carriers number which was caused by calculating it before carriers array parsing.
Because of it, the logo was rendered in wrong size when duplicate carries data were supplied.

Added test for this case.

Before/Wrong ( 2x `FR` carrier, default large size):
![before](https://user-images.githubusercontent.com/2660330/51607464-062e9080-1f15-11e9-9f0a-49b1cc56be74.JPG)

After/Correct:
![after](https://user-images.githubusercontent.com/2660330/51607476-0890ea80-1f15-11e9-9d7e-040825d42a73.JPG)