### PR TITLE
Fix: fixed the RowOption arrow design on android

### DIFF
--- a/src/RowOption/RowOptionLeftIcon.js
+++ b/src/RowOption/RowOptionLeftIcon.js
@@ -63,6 +63,9 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: -7,
     backgroundColor: 'white',
+    android: {
+      bottom: -10,
+    },
   },
   leftIconContainer: {
     justifyContent: 'center',


### PR DESCRIPTION
**Before:**
<img width="402" alt="screen shot 2019-01-30 at 13 53 24" src="https://user-images.githubusercontent.com/6354326/51983352-be6db300-2498-11e9-92cc-50d544e14756.png">

**After**
<img width="382" alt="screen shot 2019-01-30 at 14 09 54" src="https://user-images.githubusercontent.com/6354326/51983370-c9c0de80-2498-11e9-85b1-870a6e5692a2.png">
