### PR TITLE
Fix: Text component is Expo compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ import { Icon, Text, PageLoader } from "@kiwicom/universal-components";
 import { Font } from "expo";
 import OrbitIcons from "@kiwicom/universal-components/lib/fonts/orbit-icons.ttf";
 import Roboto from "@kiwicom/universal-components/lib/fonts/Roboto/Roboto-Regular.ttf";
+import RobotoItalic from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-Italic.ttf';
+import RobotoBold from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-Bold.ttf';
+import RobotoBoldItalic from '@kiwicom/universal-components/lib/fonts/Roboto/Roboto-BoldItalic.ttf';
 
 export default class App extends React.Component {
   state = {
@@ -35,7 +38,10 @@ export default class App extends React.Component {
   componentDidMount() {
     Font.loadAsync({
       "orbit-icons": OrbitIcons,
-      Roboto
+      Roboto,
+      RobotoItalic,
+      RobotoBold,
+      RobotoBoldItalic,
     }).then(() => {
       this.setState({ fontLoaded: true });
     });

--- a/src/MenuGroup/__tests__/__snapshots__/MenuItem.android.test.js.snap
+++ b/src/MenuGroup/__tests__/__snapshots__/MenuItem.android.test.js.snap
@@ -35,6 +35,7 @@ exports[`MenuGroup renders correctly 1`] = `
     >
       <View>
         <Text
+          expo={false}
           size="large"
           type="attention"
         >

--- a/src/MenuGroup/__tests__/__snapshots__/MenuItem.ios.test.js.snap
+++ b/src/MenuGroup/__tests__/__snapshots__/MenuItem.ios.test.js.snap
@@ -36,6 +36,7 @@ exports[`MenuGroup hides actionIcon 1`] = `
     >
       <View>
         <Text
+          expo={false}
           size="large"
           type="attention"
         >
@@ -90,6 +91,7 @@ exports[`MenuGroup renders correctly 1`] = `
     >
       <View>
         <Text
+          expo={false}
           size="large"
           type="attention"
         >

--- a/src/MenuGroup/__tests__/__snapshots__/MenuItem.test.js.snap
+++ b/src/MenuGroup/__tests__/__snapshots__/MenuItem.test.js.snap
@@ -49,6 +49,7 @@ exports[`MenuGroup renders with icon 1`] = `
       />
       <View>
         <Text
+          expo={false}
           size="large"
           type="attention"
         >
@@ -116,12 +117,14 @@ exports[`MenuGroup renders with label 1`] = `
     >
       <View>
         <Text
+          expo={false}
           size="small"
           type="secondary"
         >
           label
         </Text>
         <Text
+          expo={false}
           size="large"
           type="attention"
         >
@@ -189,12 +192,14 @@ exports[`MenuGroup renders with subTitle 1`] = `
     >
       <View>
         <Text
+          expo={false}
           size="large"
           type="attention"
         >
           test
         </Text>
         <Text
+          expo={false}
           size="small"
           type="secondary"
         >

--- a/src/RadioButton/__tests__/__snapshots__/index.test.js.snap
+++ b/src/RadioButton/__tests__/__snapshots__/index.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`RadioButton should match snapshot diff 1`] = `
 "Snapshot Diff:
-- <RadioButton onPress={[Function mockConstructor]}><Text>child-label</Text></RadioButton>
-+ <RadioButton bulletPosition=\\"left\\" checked={true} disabled={false} onPress={[Function mockConstructor]} style={{\\"padding\\": 10}} type=\\"bullet\\"><Text>child-label</Text></RadioButton>
+- <RadioButton onPress={[Function mockConstructor]}><Text expo={false}>child-label</Text></RadioButton>
++ <RadioButton bulletPosition=\\"left\\" checked={true} disabled={false} onPress={[Function mockConstructor]} style={{\\"padding\\": 10}} type=\\"bullet\\"><Text expo={false}>child-label</Text></RadioButton>
 
 @@ -9,12 +9,14 @@
     style={

--- a/src/Stepper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stepper/__tests__/__snapshots__/index.test.js.snap
@@ -43,6 +43,7 @@ exports[`Stepper should match the snapshot 1`] = `
     touchable={true}
   />
   <Text
+    expo={false}
     style={
       Object {
         "fontSize": 16,

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -30,6 +30,7 @@ const Text = ({
   type,
   uppercase,
   weight,
+  expo,
 }: TextType) => {
   const textStyle = [styles.text];
   if (italic) {
@@ -53,6 +54,19 @@ const Text = ({
   if (style) {
     textStyle.push(style);
   }
+
+  if (expo && (Platform.OS === 'ios' || Platform.OS === 'android')) {
+    let fontFamily = styles.normalFontFamily;
+    if (italic && weight === 'bold') {
+      fontFamily = styles.boldItalicFontFamily;
+    } else if (italic) {
+      fontFamily = styles.italicFontFamily;
+    } else if (weight === 'bold') {
+      fontFamily = styles.boldFontFamily;
+    }
+    textStyle.push(fontFamily);
+  }
+
   return (
     <RNText
       data-test={dataTest}
@@ -63,6 +77,11 @@ const Text = ({
     </RNText>
   );
 };
+
+Text.defaultProps = {
+  expo: false,
+};
+
 const styles = StyleSheet.create({
   text: {
     margin: 0,
@@ -78,6 +97,18 @@ const styles = StyleSheet.create({
   ...alignGen(),
   ...colorGen(),
   ...fontSizeGen(),
+  normalFontFamily: {
+    fontFamily: 'Roboto',
+  },
+  boldFontFamily: {
+    fontFamily: 'RobotoBold',
+  },
+  italicFontFamily: {
+    fontFamily: 'RobotoItalic',
+  },
+  boldItalicFontFamily: {
+    fontFamily: 'RobotoBoldItalic',
+  },
 });
 
 export default Text;

--- a/src/Text/TextTypes.js
+++ b/src/Text/TextTypes.js
@@ -23,4 +23,5 @@ export type TextType = {|
     | 'warning'
     | 'white',
   +weight?: 'normal' | 'bold',
+  +expo?: boolean,
 |};

--- a/src/Text/__tests__/Text.android.test.js
+++ b/src/Text/__tests__/Text.android.test.js
@@ -1,0 +1,47 @@
+// @flow
+
+import * as React from 'react';
+import { render } from 'react-native-testing-library';
+
+import Text from '../Text';
+
+jest.mock('Platform', () => ({
+  select: jest.fn(),
+  OS: 'android',
+}));
+
+describe('Text -- Android', () => {
+  it('should have the default font family', () => {
+    const boldItalic = render(
+      <Text italic weight="bold">
+        Lorem
+      </Text>,
+    );
+
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+
+  it('should have the correct font family -- EXPO', () => {
+    const normal = render(<Text expo>Lorem</Text>);
+    const bold = render(
+      <Text weight="bold" expo>
+        Lorem
+      </Text>,
+    );
+    const italic = render(
+      <Text italic expo>
+        Lorem
+      </Text>,
+    );
+    const boldItalic = render(
+      <Text italic weight="bold" expo>
+        Lorem
+      </Text>,
+    );
+
+    expect(normal.toJSON()).toMatchSnapshot();
+    expect(bold.toJSON()).toMatchSnapshot();
+    expect(italic.toJSON()).toMatchSnapshot();
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/Text/__tests__/Text.ios.test.js
+++ b/src/Text/__tests__/Text.ios.test.js
@@ -1,0 +1,47 @@
+// @flow
+
+import * as React from 'react';
+import { render } from 'react-native-testing-library';
+
+import Text from '../Text';
+
+jest.mock('Platform', () => ({
+  select: jest.fn(),
+  OS: 'ios',
+}));
+
+describe('Text -- iOS', () => {
+  it('should have the default font family', () => {
+    const boldItalic = render(
+      <Text italic weight="bold">
+        Lorem
+      </Text>,
+    );
+
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+
+  it('should have the correct font family -- EXPO', () => {
+    const normal = render(<Text expo>Lorem</Text>);
+    const bold = render(
+      <Text weight="bold" expo>
+        Lorem
+      </Text>,
+    );
+    const italic = render(
+      <Text italic expo>
+        Lorem
+      </Text>,
+    );
+    const boldItalic = render(
+      <Text italic weight="bold" expo>
+        Lorem
+      </Text>,
+    );
+
+    expect(normal.toJSON()).toMatchSnapshot();
+    expect(bold.toJSON()).toMatchSnapshot();
+    expect(italic.toJSON()).toMatchSnapshot();
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/Text/__tests__/Text.web.test.js
+++ b/src/Text/__tests__/Text.web.test.js
@@ -1,0 +1,53 @@
+// @flow
+
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { render } from 'react-native-testing-library';
+
+import Text from '../Text';
+
+const originalPlatform = Platform.OS;
+
+beforeAll(() => {
+  Platform.OS = 'web';
+});
+
+afterAll(() => {
+  Platform.OS = originalPlatform;
+});
+
+describe('Text -- Web', () => {
+  it('should have the correct font family', () => {
+    const boldItalic = render(
+      <Text italic weight="bold">
+        Lorem
+      </Text>,
+    );
+
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+
+  it('should have the default font family -- EXPO', () => {
+    const normal = render(<Text expo>Lorem</Text>);
+    const bold = render(
+      <Text weight="bold" expo>
+        Lorem
+      </Text>,
+    );
+    const italic = render(
+      <Text italic expo>
+        Lorem
+      </Text>,
+    );
+    const boldItalic = render(
+      <Text italic weight="bold" expo>
+        Lorem
+      </Text>,
+    );
+
+    expect(normal.toJSON()).toMatchSnapshot();
+    expect(bold.toJSON()).toMatchSnapshot();
+    expect(italic.toJSON()).toMatchSnapshot();
+    expect(boldItalic.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/Text/__tests__/__snapshots__/Text.android.test.js.snap
+++ b/src/Text/__tests__/__snapshots__/Text.android.test.js.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text -- Android should have the correct font family -- EXPO 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontFamily": "Roboto",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the correct font family -- EXPO 2`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "RobotoBold",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the correct font family -- EXPO 3`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontFamily": "RobotoItalic",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the correct font family -- EXPO 4`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "RobotoBoldItalic",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Android should have the default font family 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;

--- a/src/Text/__tests__/__snapshots__/Text.ios.test.js.snap
+++ b/src/Text/__tests__/__snapshots__/Text.ios.test.js.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text -- iOS should have the correct font family -- EXPO 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontFamily": "Roboto",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the correct font family -- EXPO 2`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "RobotoBold",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the correct font family -- EXPO 3`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontFamily": "RobotoItalic",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the correct font family -- EXPO 4`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+      Object {
+        "fontFamily": "RobotoBoldItalic",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- iOS should have the default font family 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;

--- a/src/Text/__tests__/__snapshots__/Text.web.test.js.snap
+++ b/src/Text/__tests__/__snapshots__/Text.web.test.js.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text -- Web should have the correct font family 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Web should have the default font family -- EXPO 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Web should have the default font family -- EXPO 2`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontWeight": "700",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Web should have the default font family -- EXPO 3`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;
+
+exports[`Text -- Web should have the default font family -- EXPO 4`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "margin": 0,
+      },
+      Object {
+        "fontStyle": "italic",
+      },
+      Object {
+        "fontWeight": "700",
+      },
+    ]
+  }
+>
+  Lorem
+</Text>
+`;

--- a/src/Tooltip/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Tooltip/__tests__/__snapshots__/index.test.js.snap
@@ -65,6 +65,7 @@ exports[`TooltipBubble should match the snapshot 1`] = `
     }
   >
     <Text
+      expo={false}
       style={
         Object {
           "color": "#fff",


### PR DESCRIPTION
Summary: Because of the way fonts are loaded in an Expo project, `fontStyle` and `fontWeight` are ignored. To make sure our Text component works in Expo apps too, an `expo` boolean prop is added to the Text component. This makes sure the right font family is used (Roboto, RobotoBold, RobotoItalic or RobotoBoldItalic) if the platform is iOS or Android and the `expo` prop is true. It also means these fonts need to be loaded (README updated).

That means that the wrapper in `margarita` will just change to have `expo` prop true by default.