### PR TITLE
Fix: Flow types work in host project

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.11",
   "description": "Component Library for React Native, Expo and React applications",
   "homepage": "https://github.com/kiwicom/universal-components",
-  "main": "lib",
+  "main": "lib/web/index.js",
+  "react-native": "lib/native/index.js",
   "scripts": {
     "docz:dev": "cd docs; yarn; yarn docz:dev",
     "docz:build": "cd docs; yarn; yarn docz:build",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,12 +4,11 @@
   "private": true,
   "scripts": {
     "postinstall": "yarn build",
-    "build": "rimraf ../lib && yarn build:copy:web && yarn build:copy:native && yarn build:copy:flow && yarn build:copy:fonts && yarn build:copy:index && yarn build:lib",
+    "build": "rimraf ../lib && yarn build:copy:web && yarn build:copy:native && yarn build:copy:flow && yarn build:copy:fonts && yarn build:lib",
     "build:copy:web": "copyfiles -u 2 '../src/**/*.js' '../src/**/*.json' '../src/**/assets/**' -e '../src/**/*.stories.js' -e '../src/**/__tests__/**' -e '../src/**/*.native.js' -e '../src/**/*.ios.js' -e '../src/**/*.android.js' ../lib/web",
     "build:copy:native": "copyfiles -u 2 '../src/**/*.js' '../src/**/*.json' '../src/**/assets/**' -e '../src/**/*.stories.js' -e '../src/**/__tests__/**' -e '../src/**/**.web.js' ../lib/native",
     "build:copy:flow": "flow-copy-source -i '**/*.stories.js' -i '**/*.test.js' -i '**/*.native.js' -i '**/*.android.js' -i '**/*.ios.js' ../src ../lib/web",
     "build:copy:fonts": "copyfiles -u 1 '../fonts/*.ttf' '../fonts/**/*.ttf' ../lib",
-    "build:copy:index": "copyfiles -u 1 ./templates/**.js ../lib",
     "build:lib": "babel --out-dir ../lib/web ../lib/web --plugins=babel-plugin-react-native-web,@babel/plugin-proposal-class-properties,@babel/plugin-proposal-nullish-coalescing-operator,@babel/plugin-proposal-optional-chaining --presets=@babel/react,@babel/flow --compact true"
   },
   "devDependencies": {

--- a/scripts/templates/index.js
+++ b/scripts/templates/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./web');

--- a/scripts/templates/index.native.js
+++ b/scripts/templates/index.native.js
@@ -1,1 +1,0 @@
-export * from './native';


### PR DESCRIPTION
Summary: Flow types were not picked up when exported as an NPM package; changing "main" and "react-native" fields in package.json to point to the right index.js files does the trick. I suspect that the previous setup was masking flow types because we were using module.exports without declaring a type for the module.