### PR TITLE
Refactor: change the OptionPicker from uncontrolled to controlled component

### DIFF
--- a/src/OptionPicker/OptionPicker.js
+++ b/src/OptionPicker/OptionPicker.js
@@ -8,142 +8,61 @@ import type { OptionType } from './OptionPickerTypes';
 import { StyleSheet } from '../PlatformStyleSheet';
 import { TagsInput } from '../TagsInput';
 import OptionList from './components/OptionList';
-import { getOptionsIds, areSelectedOptionsChanged } from './helpers';
 
 type Props = {|
+  +onChangeText: string => void,
+  +onClearPress: () => void,
+  +onPressAdd: OptionType => void,
+  +onPressItem: OptionType => void,
+  +text?: string,
   +label?: string,
+  +onKeyPress?: Event => void,
+  +options?: Array<OptionType>,
   +placeholder?: string,
-  +onChangeText: (value: string) => void,
-  +options: OptionType[],
-  +onPressAdd?: () => void,
-  +onPressItem?: () => void,
-  +onSelectedChange?: (option: Array<OptionType>) => void,
-|};
-
-type State = {|
-  selected: Array<OptionType>,
-  value: string,
+  +selected?: ?Array<OptionType>,
 |};
 
 type Event = { nativeEvent: { key: string } };
 
-const filterSubOptionsByIds = (option: OptionType, ids) => {
-  const { subOptions } = option;
-  // check if the subOptions exists
-  if (!subOptions) return option;
+export default function OptionPicker(props: Props) {
+  const {
+    options,
+    label,
+    placeholder,
+    text,
+    selected,
+    onClearPress,
+    onChangeText,
+    onKeyPress,
+    onPressItem,
+    onPressAdd,
+  } = props;
 
-  // filter out selected options
-  const filteredOptions: Array<OptionType> = subOptions.filter(
-    ({ id }) => !ids.includes(id),
-  );
-  return { ...option, ...{ subOptions: filteredOptions } };
-};
+  const tags = selected ? selected.map(option => option.label) : [];
 
-export const filterOptions = (
-  options: OptionType[],
-  selected: OptionType[],
-) => {
-  // get selectedIds
-  const selectedIDs = getOptionsIds(selected);
-
-  return options.reduce((acc = [], option) => {
-    // check if the option is selected, if yes filter it out
-    if (selectedIDs.includes(option.id)) {
-      return acc;
-    }
-    return [...acc, filterSubOptionsByIds(option, selectedIDs)];
-  }, []);
-};
-
-export default class OptionPicker extends React.Component<Props, State> {
-  state = {
-    selected: [],
-    value: '',
-  };
-
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    const { onSelectedChange } = this.props;
-    const { selected } = this.state;
-
-    if (areSelectedOptionsChanged(selected, prevState.selected)) {
-      onSelectedChange?.(selected);
-    }
-  }
-
-  handlePressAdd = (option: OptionType) => {
-    const { onPressAdd } = this.props;
-    this.setState(
-      ({ selected }) => ({ selected: [...selected, option] }),
-      onPressAdd,
-    );
-  };
-
-  handlePressItem = (option: OptionType) => {
-    const { onPressItem } = this.props;
-    this.setState({ selected: [option] }, onPressItem);
-  };
-
-  handleClear = () => {
-    this.setState({ value: '', selected: [] });
-  };
-
-  handleChangeText = (value: string) => {
-    const { onChangeText } = this.props;
-    onChangeText(value);
-    this.setState({
-      value,
-    });
-  };
-
-  handleBackspacePress = (e: Event) => {
-    const { key } = e.nativeEvent;
-    const { value } = this.state;
-
-    if (!value && key === 'Backspace') {
-      this.removeLastSelectedOption();
-    }
-  };
-
-  removeLastSelectedOption = () => {
-    const { state } = this;
-
-    // you can remove selected place only if at least one exists
-    if (state.selected.length > 0) {
-      this.setState(({ selected }) => ({
-        selected: selected.slice(0, -1),
-      }));
-    }
-  };
-
-  render() {
-    const { selected, value } = this.state;
-    const { options, label, placeholder } = this.props;
-    const tags = selected.map(option => option.label);
-
-    return (
-      <View>
-        <View style={styles.inputWrapper}>
-          <TagsInput
-            autofocus
-            tags={tags}
-            onClearPress={this.handleClear}
-            value={value}
-            onChangeText={this.handleChangeText}
-            onKeyPress={this.handleBackspacePress}
-            label={label}
-            placeholder={placeholder}
-          />
-        </View>
-        {options && (
-          <OptionList
-            onItemPress={this.handlePressItem}
-            onAddPress={this.handlePressAdd}
-            options={filterOptions(options, selected)}
-          />
-        )}
+  return (
+    <View>
+      <View style={styles.inputWrapper}>
+        <TagsInput
+          autofocus
+          tags={tags}
+          onClearPress={onClearPress}
+          value={text}
+          onChangeText={onChangeText}
+          onKeyPress={onKeyPress}
+          label={label}
+          placeholder={placeholder}
+        />
       </View>
-    );
-  }
+      {options && (
+        <OptionList
+          onItemPress={onPressItem}
+          onAddPress={onPressAdd}
+          options={options}
+        />
+      )}
+    </View>
+  );
 }
 
 const commonStyles = {

--- a/src/OptionPicker/OptionPicker.stories.js
+++ b/src/OptionPicker/OptionPicker.stories.js
@@ -2,23 +2,38 @@
 
 import * as React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, text, select, object } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import OptionPicker from './OptionPicker';
-import mockedPlaces from './mocks/places';
+import mockedPlaces, { Prague } from './mocks/places';
 
 storiesOf('OptionPicker', module)
   .addDecorator(getStory => getStory())
   .addDecorator(withKnobs)
-  .add('Playground', () => (
-    <OptionPicker
-      label={text('label', 'From:') || ''}
-      placeholder={text('placeholder', 'Departure point')}
-      onChangeText={action('onChangeText')}
-      onPressAdd={action('onPressAdd')}
-      onPressItem={action('onPressItem')}
-      options={mockedPlaces}
-      onSelectedChange={action('change')}
-    />
-  ));
+  .add('Playground', () => {
+    const onChangeText = action('onChangeText');
+    const onClearPress = action('onClearPress');
+    const onPressAdd = action('onPressAdd');
+    const onPressItem = action('onPressItem');
+    const selected = select('selected', {
+      None: null,
+      Prague: [Prague],
+    });
+    const options = object('Options', mockedPlaces);
+    const label = text('label', 'From:');
+    const placeholder = text('placeholder', 'Departure point');
+
+    return (
+      <OptionPicker
+        selected={selected}
+        onClearPress={onClearPress}
+        label={label}
+        placeholder={placeholder}
+        onChangeText={onChangeText}
+        onPressAdd={onPressAdd}
+        onPressItem={onPressItem}
+        options={options}
+      />
+    );
+  });

--- a/src/OptionPicker/__tests__/OptionPicker.test.js
+++ b/src/OptionPicker/__tests__/OptionPicker.test.js
@@ -1,17 +1,14 @@
 // @flow
 
 import React from 'react';
+import { TextInput } from 'react-native';
 import { shallow, render, fireEvent } from 'react-native-testing-library';
 
-import OptionPicker, { filterOptions } from '../OptionPicker';
+import OptionPicker from '../OptionPicker';
 import options, { Prague, Berlin } from '../mocks/places';
 import { Badge } from '../../Badge';
 
 jest.mock('NativeAnimatedHelper');
-
-test('filterOptions', () => {
-  expect(filterOptions([Prague, Berlin], [Berlin])).toEqual([Prague]);
-});
 
 describe('OptionPicker', () => {
   const label = 'label';
@@ -19,7 +16,10 @@ describe('OptionPicker', () => {
   const onChangeText = jest.fn();
   const onPressAdd = jest.fn();
   const onPressItem = jest.fn();
-  const onSelectedChange = jest.fn();
+  const onKeyPress = jest.fn();
+  const onClearPress = jest.fn();
+  const selected = [Berlin];
+  const value = Berlin.label;
 
   const {
     getByText,
@@ -27,66 +27,93 @@ describe('OptionPicker', () => {
     getByTestId,
     getAllByType,
     getByPlaceholder,
+    getByType,
   } = render(
     <OptionPicker
+      onClearPress={onClearPress}
+      onKeyPress={onKeyPress}
+      text={value}
       label={label}
+      selected={selected}
       placeholder={placeholder}
       onChangeText={onChangeText}
       options={options}
       onPressAdd={onPressAdd}
       onPressItem={onPressItem}
-      onSelectedChange={onSelectedChange}
     />,
   );
   test('passed the props', () => {
     expect(
       getByProps({
+        selected,
         onChangeText,
         options,
         onPressAdd,
         onPressItem,
-        onSelectedChange,
+        onClearPress,
+        onKeyPress,
         label,
         placeholder,
       }),
     ).toBeDefined();
     expect(getByText(label)).toBeDefined();
-    expect(getByPlaceholder(placeholder)).toBeDefined();
+    expect(getAllByType(Badge)).toHaveLength(1);
   });
 
-  test('select place', () => {
+  test('should not display placeholder', () => {
+    expect(() => getByPlaceholder(placeholder)).toThrow('No instances found');
+  });
+
+  test('call the onPressItem callback', () => {
     const Item = getByText(Prague.label);
-    expect(() => getByTestId('input-tag')).toThrow('No instances found');
     fireEvent(Item, 'press');
-    expect(getByTestId(`input-tag-${Prague.label}`)).toBeDefined();
-
-    expect(getAllByType(Badge)).toHaveLength(1);
-    expect(onPressItem).toHaveBeenCalledTimes(1);
-
-    expect(onSelectedChange).toHaveBeenCalledTimes(1);
-    expect(onSelectedChange).toHaveBeenCalledWith([Prague]);
+    expect(onPressItem).toHaveBeenCalledWith(Prague);
   });
 
-  test('select another place', () => {
-    const Item = getByText(Berlin.label);
+  test('call the onClearPress callback', () => {
+    const Item = getByTestId('delete-button');
     fireEvent(Item, 'press');
+    expect(onClearPress).toHaveBeenCalledTimes(1);
+  });
 
-    expect(onPressItem).toHaveBeenCalledTimes(2);
-    expect(onSelectedChange).toHaveBeenCalledTimes(2);
-    expect(onSelectedChange).toHaveBeenCalledWith([Berlin]);
-    expect(getAllByType(Badge)).toHaveLength(1);
+  test('call the onChangeText callback', () => {
+    fireEvent.changeText(getByType(TextInput), 'CHANGE_TEXT');
+    expect(onChangeText).toHaveBeenLastCalledWith('CHANGE_TEXT');
   });
 
   test('render', () => {
     const { output } = shallow(
       <OptionPicker
-        options={options}
-        onChangeText={onChangeText}
+        onClearPress={onClearPress}
+        onKeyPress={onKeyPress}
+        text={value}
         label={label}
+        selected={selected}
         placeholder={placeholder}
+        onChangeText={onChangeText}
+        options={options}
+        onPressAdd={onPressAdd}
+        onPressItem={onPressItem}
       />,
     );
 
     expect(output).toMatchSnapshot();
+  });
+
+  test('should display placeholder', () => {
+    const { getByPlaceholder } = render(
+      <OptionPicker
+        text=""
+        onClearPress={onClearPress}
+        onKeyPress={onKeyPress}
+        label={label}
+        placeholder={placeholder}
+        onChangeText={onChangeText}
+        options={options}
+        onPressAdd={onPressAdd}
+        onPressItem={onPressItem}
+      />,
+    );
+    expect(getByPlaceholder(placeholder)).toBeDefined();
   });
 });

--- a/src/OptionPicker/__tests__/__snapshots__/OptionPicker.test.js.snap
+++ b/src/OptionPicker/__tests__/__snapshots__/OptionPicker.test.js.snap
@@ -15,17 +15,80 @@ exports[`OptionPicker render 1`] = `
       autofocus={true}
       fontSize={16}
       label="label"
-      onChangeText={[Function]}
-      onClearPress={[Function]}
-      onKeyPress={[Function]}
+      onChangeText={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              "CHANGE_TEXT",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      onClearPress={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      onKeyPress={[MockFunction]}
       placeholder="placeholder"
-      tags={Array []}
-      value=""
+      tags={
+        Array [
+          "Berlin",
+        ]
+      }
+      value="Berlin"
     />
   </View>
   <OptionList
-    onAddPress={[Function]}
-    onItemPress={[Function]}
+    onAddPress={[MockFunction]}
+    onItemPress={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "id": "prague",
+              "label": "Prague",
+              "subOptions": Array [
+                Object {
+                  "id": "train-station",
+                  "label": "Prague Central Station",
+                  "text": "5 km from city center",
+                  "type": "train",
+                },
+                Object {
+                  "id": "airport",
+                  "label": "Václav Havel Airport",
+                  "text": "5 km from city center",
+                  "type": "airplane",
+                },
+              ],
+              "text": "Czech Republic",
+              "type": "destination",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
     options={
       Array [
         Object {


### PR DESCRIPTION
I had to refactor the OptionalPicker from uncontrolled component to controlled component. 
As uncontrolled and stateful components it works nice but just in the storybook, If I tried implemented this in the Margarita I realized, that I need
changes the OptionalPicker's state from parents, there were two options one
use ' getDerivedStateFromProps()' but this will lead to a lot of complexity.
So I decided to change OptionalPicker to a stateless uncontrolled component.