### PR TITLE
Fix: CarrierLogo styles

### DIFF
--- a/src/CarrierLogo/CarrierLogo.js
+++ b/src/CarrierLogo/CarrierLogo.js
@@ -22,6 +22,7 @@ export default function CarrierLogo({
       style={[
         styles.wrapper,
         carriersLength > 1 ? sizeStyles[SIZE_OPTIONS.LARGE] : sizeStyles[size],
+        carriersLength > 2 && styles.wrapperSpaceBetween,
       ]}
     >
       {parsedCarriers.map((carrierData, index) => (
@@ -60,9 +61,11 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexWrap: 'wrap',
     flexDirection: 'column',
-    alignContent: 'space-between',
     justifyContent: 'space-between',
     backgroundColor: defaultTokens.backgroundCarrierLogo,
+  },
+  wrapperSpaceBetween: {
+    alignContent: 'space-between',
   },
   logo: {
     backgroundColor: defaultTokens.backgroundCarrierLogo,

--- a/src/CarrierLogo/__tests__/__snapshots__/index.test.js.snap
+++ b/src/CarrierLogo/__tests__/__snapshots__/index.test.js.snap
@@ -7,13 +7,21 @@ exports[`CarrierLogo should match snapshot diff 1`] = `
 - <CarrierLogo carriers={[{\\"code\\": \\"FR\\", \\"name\\": \\"Ryanair\\"}]} />
 + <CarrierLogo carriers={[{\\"code\\": \\"FR\\", \\"name\\": \\"Ryanair\\"}, {\\"code\\": \\"TO\\", \\"name\\": \\"Transavia France\\"}, {\\"code\\": \\"VY\\", \\"name\\": \\"Vueling\\"}, {\\"code\\": \\"OK\\", \\"name\\": \\"Czech Airlines\\"}]} />
 
-@@ -17,22 +17,82 @@
-    }
-  >
-    <Image
-      source={
+@@ -10,29 +10,91 @@
+        },
         Object {
--         \\"uri\\": \\"https://images.kiwi.com/airlines/64/FR.png?default=airline.png\\",
+          \\"height\\": 32,
+          \\"width\\": 32,
+        },
++       Object {
++         \\"alignContent\\": \\"space-between\\",
++       },
++     ]
++   }
++ >
++   <Image
++     source={
++       Object {
 +         \\"uri\\": \\"https://images.kiwi.com/airlines/32/FR.png?default=airline.png\\",
 +       }
 +     }
@@ -27,13 +35,15 @@ exports[`CarrierLogo should match snapshot diff 1`] = `
 +           \\"height\\": 15,
 +           \\"width\\": 15,
 +         },
-+         false,
-+       ]
-+     }
+          false,
+        ]
+      }
+- >
 +   />
-+   <Image
-+     source={
-+       Object {
+    <Image
+      source={
+        Object {
+-         \\"uri\\": \\"https://images.kiwi.com/airlines/64/FR.png?default=airline.png\\",
 +         \\"uri\\": \\"https://images.kiwi.com/airlines/32/TO.png?default=airline.png\\",
         }
       }


### PR DESCRIPTION
Summary: In case of two carriers logos were aligned vertically instead of diagonally in latest version of Chrome and Firefox.

Before
<img width="44" alt="screenshot 2019-02-15 at 12 22 27" src="https://user-images.githubusercontent.com/2660330/52857793-743b3180-3128-11e9-9032-3921dc4ed888.png">

After
<img width="43" alt="screenshot 2019-02-15 at 12 22 13" src="https://user-images.githubusercontent.com/2660330/52857796-77362200-3128-11e9-86b5-735d89951c32.png">

Also reported this issue to `orbit-components` team because we are using same styling ( https://github.com/kiwicom/orbit-components/issues/821 ).