### PR TITLE
Styling prop for TextInput's label container

### DIFF
--- a/src/TextInput/FormLabel.js
+++ b/src/TextInput/FormLabel.js
@@ -5,7 +5,7 @@ import { defaultTokens } from '@kiwicom/orbit-design-tokens';
 import { View } from 'react-native';
 
 import { Text } from '../Text';
-import { StyleSheet } from '../PlatformStyleSheet';
+import { StyleSheet, type StylePropType } from '../PlatformStyleSheet';
 
 type Props = {|
   +children: React.Node,
@@ -13,6 +13,7 @@ type Props = {|
   +disabled?: boolean,
   +required?: boolean,
   +inlineLabel?: boolean,
+  +style?: StylePropType,
 |};
 
 const getAsteriksStyle = (filled, disabled) => {
@@ -35,9 +36,12 @@ export default function FormLabel({
   filled,
   disabled,
   inlineLabel,
+  style,
 }: Props) {
   return (
-    <View style={inlineLabel ? styles.inlineFormLabel : styles.formLabel}>
+    <View
+      style={[inlineLabel ? styles.inlineFormLabel : styles.formLabel, style]}
+    >
       {required && (
         <Asteriks filled={filled} disabled={disabled}>
           *{' '}

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -154,6 +154,7 @@ class TextInput extends React.Component<Props, State> {
       required,
       prefix,
       inlineLabel,
+      labelContainerStyle,
       suffix,
       type = 'text',
       error,
@@ -183,7 +184,12 @@ class TextInput extends React.Component<Props, State> {
       <TouchableWithoutFeedback onPress={this.focusTextInput}>
         <View style={styles.inputWrapper}>
           {label != null && !inlineLabel && (
-            <FormLabel filled={!!value} required={required} disabled={disabled}>
+            <FormLabel
+              style={[styles.labelContainer, labelContainerStyle]}
+              filled={!!value}
+              required={required}
+              disabled={disabled}
+            >
               {label}
             </FormLabel>
           )}
@@ -206,6 +212,7 @@ class TextInput extends React.Component<Props, State> {
             {label != null && inlineLabel && (
               <InlineLabel>
                 <FormLabel
+                  style={labelContainerStyle}
                   filled={!!value}
                   inlineLabel
                   required={required}
@@ -339,6 +346,9 @@ const styles = StyleSheet.create({
   },
   textInputPrefix: {
     color: defaultTokens.colorTextInputPrefix,
+  },
+  labelContainer: {
+    marginLeft: 10,
   },
   ...fontSizeGen(),
   ...heightGen(),

--- a/src/TextInput/TextInputTypes.js
+++ b/src/TextInput/TextInputTypes.js
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import { type StylePropType } from '../PlatformStyleSheet';
+
 export type Props = {|
   +autoCorrect?: boolean,
   +autoFocus?: boolean,
@@ -23,6 +25,7 @@ export type Props = {|
   +error?: React.Node,
   +help?: React.Node,
   +status?: 'default' | 'success' | 'warning', // this prop is supported only on mobile
+  +labelContainerStyle?: StylePropType,
 |};
 
 export type State = {|

--- a/src/TextInput/__tests__/__snapshots__/index.test.js.snap
+++ b/src/TextInput/__tests__/__snapshots__/index.test.js.snap
@@ -5,12 +5,12 @@ exports[`TextInput should match snapshot diff between small and normal input 1`]
 - <TextInput label=\\"Label\\" />
 + <TextInput label=\\"Label\\" size=\\"small\\" />
 
-@@ -47,3 +47,3 @@
+@@ -55,3 +55,3 @@
           Object {
 -           \\"height\\": 44,
 +           \\"height\\": 32,
           },
-@@ -80,3 +80,3 @@
+@@ -88,3 +88,3 @@
             Object {
 -             \\"height\\": 44,
 +             \\"height\\": 32,


### PR DESCRIPTION
Without this, I'm not able to style form labels properly, because I can change only text-related styles

<img width="333" alt="screenshot 2019-02-25 at 10 10 52" src="https://user-images.githubusercontent.com/858321/53326446-e90b2a00-38e5-11e9-8300-5b00f2cb3d16.png">
